### PR TITLE
Add option to disable social widget replacement

### DIFF
--- a/skin/popup.html
+++ b/skin/popup.html
@@ -57,6 +57,10 @@
 <center><button id="deactivate_site_btn" class="control-button grey-button" style="display:"> Disable Privacy Badger for This Site</button></center>
 <center><button id="activate_site_btn" class="control-button red-button" style="display:none"> Enable Privacy Badger for This Site</button></center>
 </div>
+<div id="socialWidgetControls">
+<center><button id="deactivate_socialwidget_btn" class="control-button grey-button" style="display:"> Disable Social Widget Replacement</button></center>
+<center><button id="activate_socialwidget_btn" class="control-button red-button" style="display:none"> Enable Social Widget Replacement</button></center>
+</div>
 <center><button id="deactivate_btn" class="control-button grey-button" style="display:block"> Deactivate Privacy Badger </button></center>
 <center><button id="activate_btn" class="control-button red-button" style="display:none"> Activate Privacy Badger</button></center>
 <div class='clear'></div>

--- a/src/background.js
+++ b/src/background.js
@@ -38,6 +38,10 @@ if (!("enabled" in localStorage)){
   localStorage.enabled = "true";
 }
 
+if (!("socialWidgetReplacementEnabled" in localStorage)){
+  localStorage.socialWidgetReplacementEnabled = "true";
+}
+
 with(require("filterClasses")) {
   this.Filter = Filter;
   this.RegExpFilter = RegExpFilter;

--- a/src/popup.js
+++ b/src/popup.js
@@ -69,6 +69,8 @@ function init()
   $("#deactivate_btn").click(deactivate);
   $("#activate_site_btn").click(active_site);
   $("#deactivate_site_btn").click(deactive_site);
+  $("#activate_socialwidget_btn").click(active_socialwidget);
+  $("#deactivate_socialwidget_btn").click(deactive_socialwidget);
   //$("#enabled").click(toggleEnabled);
   
   // Initialize based on activation state
@@ -78,6 +80,11 @@ function init()
       $("#activate_btn").show();
       $("#deactivate_btn").hide();
       $("#siteControls").hide();
+      $("#socialWidgetControls").hide();
+    }
+    if(!Utils.isSocialWidgetReplacementEnabled()) {
+      $("#activate_socialwidget_btn").show();
+      $("#deactivate_socialwidget_btn").hide();
     }
     $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
     $('#blockedResourcesContainer').on('mouseenter', '.tooltip', displayTooltip);
@@ -95,6 +102,7 @@ function init()
         $("#blockedResourcesContainer").hide();
         $("#activate_site_btn").show();
         $("#deactivate_site_btn").hide();
+	$("#socialWidgetControls").hide();
       }
     });
   });
@@ -106,6 +114,7 @@ function activate() {
   $("#deactivate_btn").toggle();
   $("#blockedResourcesContainer").show();
   $("#siteControls").show();
+  $("#socialWidgetControls").show();
   localStorage.enabled = "true";
   refreshIconAndContextMenu(tab);
   reloadTab(tab.id);
@@ -116,6 +125,7 @@ function deactivate() {
   $("#deactivate_btn").toggle();
   $("#blockedResourcesContainer").hide();
   $("#siteControls").hide();
+  $("#socialWidgetControls").hide();
   localStorage.enabled = "false";
   refreshIconAndContextMenu(tab);
   reloadTab(tab.id);
@@ -125,6 +135,7 @@ function active_site(){
   $("#activate_site_btn").toggle();
   $("#deactivate_site_btn").toggle();
   $("#blockedResourcesContainer").show();
+  $("#socialWidgetControls").show();
   Utils.enablePrivacyBadgerForOrigin(extractHostFromURL(tab.url));
   refreshIconAndContextMenu(tab);
   reloadTab(tab.id);
@@ -134,11 +145,27 @@ function deactive_site(){
   $("#activate_site_btn").toggle();
   $("#deactivate_site_btn").toggle();
   $("#blockedResourcesContainer").hide();
+  $("#socialWidgetControls").hide();
   Utils.disablePrivacyBadgerForOrigin(extractHostFromURL(tab.url));
   refreshIconAndContextMenu(tab);
   reloadTab(tab.id);
 }
 
+function active_socialwidget(){
+  $("#activate_socialwidget_btn").toggle();
+  $("#deactivate_socialwidget_btn").toggle();
+  localStorage.socialWidgetReplacementEnabled = "true";
+  refreshIconAndContextMenu(tab);
+  reloadTab(tab.id);
+}
+
+function deactive_socialwidget(){
+  $("#activate_socialwidget_btn").toggle();
+  $("#deactivate_socialwidget_btn").toggle();
+  localStorage.socialWidgetReplacementEnabled = "false";
+  refreshIconAndContextMenu(tab);
+  reloadTab(tab.id);
+}
 
 function revertDomainControl(e){
   $elm = $(e.target).parent();

--- a/src/utils.js
+++ b/src/utils.js
@@ -184,7 +184,11 @@ var Utils = exports.Utils = {
    * (TODO: actually make this return something based on a user-facing setting
    */
   isSocialWidgetReplacementEnabled: function() {
-    return true;
+    if (!JSON.parse(localStorage.socialWidgetReplacementEnabled)) {
+      return false;
+    } else {
+      return true;
+    }
   },
 
   /**


### PR DESCRIPTION
Adds an option in the Privacy Badger popup to allow the user to toggle social media widget replacement (fixes #228).