### PR TITLE
Bug fixes

### DIFF
--- a/src/heuristicblocking.js
+++ b/src/heuristicblocking.js
@@ -630,7 +630,7 @@ var heuristicBlockingAccounting = function(details) {
   else {
     var tabOrigin = tabOrigins[details.tabId];
     // Ignore first-party requests
-    if (origin == tabOrigin)
+    if (!tabOrigin || origin == tabOrigin)
       return { };
     // if there are no tracking cookies or similar things, ignore
     if (!hasTracking(details, origin)){

--- a/src/heuristicblocking.js
+++ b/src/heuristicblocking.js
@@ -630,8 +630,9 @@ var heuristicBlockingAccounting = function(details) {
   else {
     var tabOrigin = tabOrigins[details.tabId];
     // Ignore first-party requests
-    if (!tabOrigin || origin == tabOrigin)
+    if (!tabOrigin || origin == tabOrigin){
       return { };
+    }
     // if there are no tracking cookies or similar things, ignore
     if (!hasTracking(details, origin)){
       return { };

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,14 +181,9 @@ var Utils = exports.Utils = {
 
   /**
    * check if social widget replacement functionality is enabled
-   * (TODO: actually make this return something based on a user-facing setting
    */
   isSocialWidgetReplacementEnabled: function() {
-    if (!JSON.parse(localStorage.socialWidgetReplacementEnabled)){
-      return false;
-    } else {
-      return true;
-    }
+    return JSON.parse(localStorage.socialWidgetReplacementEnabled)
   },
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -183,7 +183,7 @@ var Utils = exports.Utils = {
    * check if social widget replacement functionality is enabled
    */
   isSocialWidgetReplacementEnabled: function() {
-    return JSON.parse(localStorage.socialWidgetReplacementEnabled)
+    return JSON.parse(localStorage.socialWidgetReplacementEnabled);
   },
 
   /**

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -340,7 +340,7 @@ function getSocialWidgetBlockList(tabId) {
   // a mapping of individual SocialWidget objects to boolean values
   // saying if the content script should replace that tracker's buttons
   var socialWidgetsToReplace = {};
-  green_domains = {}
+  green_domains = {};
   var green = FilterStorage.knownSubscriptions.userGreen.filters;
   for( var i = 0; i < green.length; i++){
       green_domains[green[i].regexp.source] = 1;

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -340,18 +340,22 @@ function getSocialWidgetBlockList(tabId) {
   // a mapping of individual SocialWidget objects to boolean values
   // saying if the content script should replace that tracker's buttons
   var socialWidgetsToReplace = {};
+  green_domains = {}
+  var green = FilterStorage.knownSubscriptions.userGreen.filters;
+  for( var i = 0; i < green.length; i++){
+      green_domains[green[i].regexp.source] = 1;
+  }
 
   SocialWidgetList.forEach(function(socialwidget) {
     var socialWidgetName = socialwidget.name;
 
-    // replace them if PrivacyBadger has blocked them
+    // replace them if the user hasn't greened them
     var blockedData = activeMatchers.blockedOriginsByTab[tabId];
-    if (blockedData && blockedData[socialwidget.domain]) {
-      socialWidgetsToReplace[socialWidgetName] = (blockedData[socialwidget.domain].latestaction == "block"
-	      					  || blockedData[socialwidget.domain].latestaction == "userblock");
+    if (socialwidget.domain in green_domains) {
+        socialWidgetsToReplace[socialWidgetName] = false;
     }
     else {
-      socialWidgetsToReplace[socialWidgetName] = false;
+        socialWidgetsToReplace[socialWidgetName] = true;
     }
   });
 


### PR DESCRIPTION
the change to src/heuristicBlocking prevents tabs from setting themselves as an instance of 3rd party tracking by checking if tabOrigin is undefined
the other changes now block social widgets in all instances when the user hasn't explicitly set them to noaction (userGreen)