### PR TITLE
Ignore unattributed fingerprinting for now.

### DIFF
--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -252,6 +252,12 @@ function recordFrame(tabId, frameId, parentFrameId, frameUrl) {
 }
 
 function recordFingerprinting(tabId, msg) {
+  // bail if we failed to determine the originating script's URL
+  // TODO find and fix where this happens
+  if (!msg.scriptUrl) {
+    return;
+  }
+
   // ignore first-party scripts
   var script_host = extractHostFromURL(msg.scriptUrl),
     document_host = extractHostFromURL(getFrameUrl(tabId, 0));


### PR DESCRIPTION
Artificial scenario where we fail to get the originating script: https://jsfiddle.net/Lfrzyywq/2/.