### PR TITLE
Remove Google+1 selector which causes double blocking (#402).

### DIFF
--- a/src/socialwidgets.json
+++ b/src/socialwidgets.json
@@ -73,8 +73,7 @@
 		"domain": "apis.google.com",
 		"buttonSelectors": [
 			"g\\:plusone",
-			".g-plusone",
-			"#___plusone_0"
+			".g-plusone"
 		],
 		"replacementButton": {
 			"details": "https://plusone.google.com/se/0/_/+1/fastbutton?url=",


### PR DESCRIPTION
This commit should fix issue #402. The selector (`#___plusone_0`) removed in this commit caused PB to sometimes replace a Google Plus(+1) button with two replacement buttons.

At the heart of the issue is a strange race condition. Before [adding this selector](https://github.com/EFForg/privacybadgerchrome/pull/395/files#diff-a7e3669d2b1a8fab33514e1059d4cc30R77), sometimes (at least on my not-so-slow computer) +1 buttons had been rendered so quickly that PB couldn't replace them. This was because PB was looking for elements (`g:plusone` and `div.g-plusone`) that were already removed during the rendering of the +1 button.
This issue will again be visible after this commit (i.e. PB will sometimes miss +1 buttons) and I'll file a separate issue for that.
But (now I understand) it doesn't make sense to use the `#___plusone_0` selector, since it tries to find an already rendered +1 button's div (which is too late for replacing a social widget).

