### PR TITLE
Enable tooltips on PB Options page. Add selenium tests.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -55,9 +55,8 @@ function loadOptions()
   // load resources for filter sliders
   $(function () {
     $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);   
-    // TODO get tooltips to work 
-    //$('#blockedResourcesContainer').on('mouseenter', '.tooltip', displayTooltip);
-    //$('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);   
+    $('#blockedResourcesContainer').on('mouseenter', '.tooltip', displayTooltip);
+    $('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);
     $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
   });
 

--- a/setup_travis.sh
+++ b/setup_travis.sh
@@ -10,9 +10,8 @@ else
     elif [ $machine = "i686" ] ; then 
         bits="32"; 
     fi;
-    version="2.10"  # TODO read directly from version
-    wget -O /tmp/chromedriver.zip "http://chromedriver.storage.googleapis.com/$version/chromedriver_linux$bits.zip"
+    version="2.12"
+    wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/$version/chromedriver_linux$bits.zip"
     sudo unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
     sudo chmod a+x /usr/local/bin/chromedriver
 fi
-

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import unittest
+import pbtest
+from time import sleep
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import TimeoutException
+
+
+class OptionsPageTest(pbtest.PBSeleniumTest):
+    """Make sure the options page works correctly."""
+
+    def hide_tooltip(self, css_selector):
+        """Hide the tooltip by moving to a tooltip-less element."""
+        # The below element (ui-id-1) is specific to Options page.
+        el_no_hover = self.driver.find_element_by_id("ui-id-1")
+        ActionChains(self.driver).move_to_element(el_no_hover).perform()
+        WebDriverWait(self.driver, 5).until(EC.invisibility_of_element_located(
+            (By.CSS_SELECTOR, css_selector)))
+
+    def test_should_display_tooltips_on_hover(self):
+        driver = self.driver
+        find_el_by_css = driver.find_element_by_css_selector
+        TOOLTIP_TXTS = ("Move the slider left to block a domain.",
+                        "Center the slider to block cookies.",
+                        "Move the slider right to allow a domain.")
+        # We need some tracking domains to be listed in "User Filter Settings"
+        # Visit a newspaper page to get some tracker domains
+        driver.get("https://nytimes.com/")
+        sleep(3)
+        # For an unknown reason, PB Options page cannot be rendered correctly
+        # during the first visit. Visiting twice solves the problem.
+        driver.get(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
+        driver.get(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
+        # Click to the second tab (User Filter Settings)
+        driver.find_element_by_id("ui-id-2").click()
+        tooltip_css = "div.keyContainer > div > div.tooltipContainer"
+        for icon_no in xrange(1, 4):  # repeat for all three icons
+            # CSS selector for icons in the keyContainer
+            ico_css = "div.keyContainer > div > img:nth-child(%s)" % icon_no
+            icon_to_hover = find_el_by_css(ico_css)
+            ActionChains(driver).move_to_element(icon_to_hover).perform()
+            try:
+                tooltip_el = WebDriverWait(driver, 5).until(
+                    EC.visibility_of_element_located((By.CSS_SELECTOR,
+                                                      tooltip_css)))
+            except TimeoutException as e:
+                self.fail("Tooltip isn't displayed for keyContainer icon %s %s"
+                          % (icon_no, e))
+            # compare the tooltip text, should be updated after L10n
+            self.assertEqual(TOOLTIP_TXTS[icon_no-1], tooltip_el.text)
+            self.hide_tooltip(tooltip_css)
+
+        # Make sure the tooltip is displayed when we hover over an origin
+        # Only tests the first origin
+        first_origin_css = "div.clickerContainer > div:nth-child(1)"
+        origin_el_to_hover = find_el_by_css(first_origin_css + " > div.origin")
+        orig_tooltip_css = first_origin_css + " > div.tooltipContainer"
+        # move the cursor over the first tracker origin on the list
+        ActionChains(driver).move_to_element(origin_el_to_hover).perform()
+        try:
+            WebDriverWait(driver, 5).until(
+                EC.visibility_of_element_located((By.CSS_SELECTOR,
+                                                 orig_tooltip_css)))
+        except TimeoutException as e:
+            self.fail("Tooltip is not displayed for tracker origin. %s" % e)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -11,13 +11,18 @@ from selenium.webdriver.chrome.options import Options
 # PB_EXT_BG_URL_BASE = "chrome-extension://pkehgijcmpdhfbdbbnkijodmdjhbjlgp/"
 PB_EXT_BG_URL_BASE = "chrome-extension://mcgekeccgjgcmhnhbabplanchdogjcnh/"
 PB_CHROME_BG_URL = PB_EXT_BG_URL_BASE + "_generated_background_page.html"
+PB_CHROME_OPTIONS_PAGE_URL = PB_EXT_BG_URL_BASE + "skin/options.html"
 
 
 class PBSeleniumTest(unittest.TestCase):
     def setUp(self):
         env = os.environ
         self.browser_bin = env.get("BROWSER_BIN", "")  # o/w use WD's default
-        self.xvfb = int(env.get("ENABLE_XVFB", 1))  # enabled by default
+        if "TRAVIS" in os.environ:
+            self.xvfb = 1
+        else:
+            # by default don't use XVFB if we are not running on CI
+            self.xvfb = int(env.get("ENABLE_XVFB", 0))
         self.pb_ext_path = self.get_extension_path()  # path to the extension
         if self.xvfb:
             self.vdisplay = Xvfb(width=1280, height=720)
@@ -31,7 +36,7 @@ class PBSeleniumTest(unittest.TestCase):
         if "PB_EXT_PATH" in os.environ:
             return os.environ["PB_EXT_PATH"]
         else:  # check the default path if PB_EXT_PATH env. variable is empty
-            print "Can't find the environment variable PB_EXT_PATH"
+            print "Can't find the env. variable PB_EXT_PATH, will check ../.."
             # if the PB_EXT_PATH environment variable is not set
             # check the default location for the last modified crx file
             exts = glob("../../*.crx")  # get matching files


### PR DESCRIPTION
Disable XVFB by default while running Selenium tests individually.
Switch to HTTPS URL for downloading ChromeDriver.
Upgrade ChromeDriver version to 2.12 for Selenium tests.