### PR TITLE
Remove implicit Webdriver waits, retry loading PB options page in case of failure.

### DIFF
--- a/tests/selenium/breakage_test.py
+++ b/tests/selenium/breakage_test.py
@@ -3,7 +3,8 @@
 
 import unittest
 import pbtest
-from time import sleep
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 class Test(pbtest.PBSeleniumTest):
@@ -15,15 +16,14 @@ class Test(pbtest.PBSeleniumTest):
 
     def test_should_load_eff_org(self):
         self.driver.get("https://www.eff.org")
-        self.assertIn("Electronic Frontier Foundation", self.driver.title)
+        WebDriverWait(self.driver, 10).until(EC.title_contains("Electronic Frontier Foundation"))
 
     def test_should_search_google(self):
         self.driver.get("https://www.google.com/")
         qry_el = self.driver.find_element_by_name("q")
         qry_el.send_keys("EFF")  # search term
         qry_el.submit()
-        sleep(5)  # give time to load the results and update the title
-        self.assertIn("EFF", self.driver.title)
+        WebDriverWait(self.driver, 10).until(EC.title_contains("EFF"))
 
 
 if __name__ == "__main__":

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -24,7 +24,7 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
 
     def test_should_display_tooltips_on_hover(self):
         driver = self.driver
-        find_el_by_css = driver.find_element_by_css_selector
+        find_el_by_css = self.find_el_by_css  # find with WebDriver wait
         TOOLTIP_TXTS = ("Move the slider left to block a domain.",
                         "Center the slider to block cookies.",
                         "Move the slider right to allow a domain.")

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -32,12 +32,23 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
         # Visit a newspaper page to get some tracker domains
         driver.get("https://nytimes.com/")
         sleep(3)
+        MAX_TRY_LOAD_PB_OPTIONS = 5
+        tried = 0
         # For an unknown reason, PB Options page cannot be rendered correctly
-        # during the first visit. Visiting twice solves the problem.
-        driver.get(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
-        driver.get(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
-        # Click to the second tab (User Filter Settings)
-        driver.find_element_by_id("ui-id-2").click()
+        # during the first visit or sometimes throw a TimeOutException.
+        # Try visiting a couple of times.
+        while tried < MAX_TRY_LOAD_PB_OPTIONS:
+            tried += 1
+            try:
+                driver.get(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
+                print "\nLoaded", pbtest.PB_CHROME_OPTIONS_PAGE_URL, tried
+                # Click to the second tab (User Filter Settings)
+                driver.find_element_by_id("ui-id-2").click()
+            except:
+                pass
+            else:
+                break
+
         tooltip_css = "div.keyContainer > div > div.tooltipContainer"
         for icon_no in xrange(1, 4):  # repeat for all three icons
             # CSS selector for icons in the keyContainer

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -46,8 +46,11 @@ class PBSeleniumTest(unittest.TestCase):
 
     def txt_by_css(self, css_selector):
         """Find an element by CSS selector and return it's text."""
+        return self.find_el_by_css(css_selector).text
+
+    def find_el_by_css(self, css_selector):
         return WebDriverWait(self.driver, 30).until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, css_selector))).text
+            EC.presence_of_element_located((By.CSS_SELECTOR, css_selector)))
 
     def get_chrome_driver(self):
         """Setup and return a Chrom[e|ium] browser for Selenium."""

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -7,6 +7,9 @@ from glob import glob
 from xvfbwrapper import Xvfb
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
 
 # PB_EXT_BG_URL_BASE = "chrome-extension://pkehgijcmpdhfbdbbnkijodmdjhbjlgp/"
 PB_EXT_BG_URL_BASE = "chrome-extension://mcgekeccgjgcmhnhbabplanchdogjcnh/"
@@ -28,7 +31,6 @@ class PBSeleniumTest(unittest.TestCase):
             self.vdisplay = Xvfb(width=1280, height=720)
             self.vdisplay.start()
         self.driver = self.get_chrome_driver()
-        self.driver.implicitly_wait(10)
         self.js = self.driver.execute_script
 
     def get_extension_path(self):
@@ -44,7 +46,8 @@ class PBSeleniumTest(unittest.TestCase):
 
     def txt_by_css(self, css_selector):
         """Find an element by CSS selector and return it's text."""
-        return self.driver.find_element_by_css_selector(css_selector).text
+        return WebDriverWait(self.driver, 30).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, css_selector))).text
 
     def get_chrome_driver(self):
         """Setup and return a Chrom[e|ium] browser for Selenium."""


### PR DESCRIPTION
We had this strange test failure ([build 66919699](https://travis-ci.org/EFForg/privacybadgerchrome/builds/66919699)) while loading the PB options page, which may be due to [mixing implicit and explicit WebDriver waits](http://www.seleniumhq.org/docs/04_webdriver_advanced.jsp#explicit-and-implicit-waits). This PR removes implicit waits and retries loading PB options page multiple times.