### PR TITLE
Fix the wrong i18n key for PB's Options page title, add test.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -43,8 +43,8 @@ var Synchronizer = require("synchronizer").Synchronizer;
 // Loads options from localStorage and sets UI elements accordingly
 function loadOptions()
 {
-  // Set page title to i18n version of "Adblock Plus Options"
-  document.title = i18n.getMessage("options");
+  // Set page title to i18n version of "Privacy Badger Options"
+  document.title = i18n.getMessage("options_title");
 
   // Add event listeners
   window.addEventListener("unload", unloadOptions, false);

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -22,6 +22,16 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
         WebDriverWait(self.driver, 5).until(EC.invisibility_of_element_located(
             (By.CSS_SELECTOR, css_selector)))
 
+    def test_page_title(self):
+        self.driver.get(pbtest.PB_CHROME_BG_URL)  # load a dummy page
+        self.driver.get(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
+        localized_title = self.js('return i18n.getMessage("options_title")')
+        try:
+            WebDriverWait(self.driver, 3).until(EC.title_contains(localized_title))
+        except:
+            self.fail("Unexpected title for the Options page. Got (%s), expected (%s)"
+                      % (self.driver.title, localized_title))
+
     def test_should_display_tooltips_on_hover(self):
         driver = self.driver
         find_el_by_css = self.find_el_by_css  # find with WebDriver wait


### PR DESCRIPTION
Fixes title of the PB Options page.