### PR TITLE
Yellowlist soundcloud's CDN

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -464,3 +464,4 @@
 @@||gatherer.wizards.com^$third-party
 @@||googlevideo.com^$third-party
 @@||piratebay.org^$third-party
+@@||sndcdn.com^$third-party


### PR DESCRIPTION
sndcdn has a lot of subdomains.

I see the following:

**a-v2.sndcdn.com**
**wis.sndcdn.com**
**ec-media.sndcdn.com**
i1.sndcdn.com
i2.sndcdn.com
i3.sndcdn.com
i4.sndcdn.com
style.sndcdn.com

Music seems to play correctly with just the bolded ones yellow, but it seems safest to yellowlist everything?