### PR TITLE
Don't check policy key name.

### DIFF
--- a/tests/selenium/localstorage_test.py
+++ b/tests/selenium/localstorage_test.py
@@ -39,8 +39,8 @@ class LocalStorageTest(pbtest.PBSeleniumTest):
             policy_json = json.loads(policy_hash)
         except:
             self.fail("localStorage.badgerHashes is not valid JSON")
-        for k, v in policy_json.iteritems():
-            self.assertIn("DNT Policy", k)  # e.g. DNT Policy V1.0
+        for _, v in policy_json.iteritems():
+            # self.assertIn("DNT Policy", k)  # e.g. DNT Policy V1.0
             self.assertEqual(PB_POLICY_HASH_LEN, len(v))  # check hash length
 
     def test_should_init_local_storage_entries(self):


### PR DESCRIPTION
Changes in the policy names causes some tests to fail, only check the policy hash length.
https://travis-ci.org/EFForg/privacybadgerchrome/builds/74160685
https://github.com/EFForg/privacybadgerchrome/pull/517#event-374608802
