### PR TITLE
[fixes: #600] "nonTrackers" Box is to small for German Translation 

### DIFF
--- a/skin/popup.css
+++ b/skin/popup.css
@@ -228,7 +228,7 @@ font-size: 16px;
   text-align: center;
   color: #f9f9f9;
   background: #555;
-  height: 20px;
+  height: auto;
   font-size: 14px;
   font-weight: bold;
 }


### PR DESCRIPTION
The German Translation for "The Domains below Don't seem to Track you" so
so long that the the words wrap out of the gray box

solution: set the box container height to "auto"

see Issue:  https://github.com/EFForg/privacybadgerchrome/issues/600