### PR TITLE
Tooltip shows complete domain name, issue 594

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -3,13 +3,13 @@
         "message": "Domain hinzufügen"
     },
     "badger_status_block": {
-        "message": "Dieser Tracker ist BLOCKIERT. Schieben, um Blockierung aufzuheben oder Cookies zu blocken."
+        "message": "Gesperrt "
     },
     "badger_status_cookieblock": {
-        "message": "Die Cookies dieses Trackers sind blockiert. Schieben, um den Tracker zu blockieren oder komplett frei zu schalten."
+        "message": "Blockiert Cookies von "
     },
     "badger_status_noaction": {
-        "message": "Diese Domain ist nicht blockiert. Schieben, um komplett zu blocken oder Cookies zu blocken."
+        "message": "Dürfen "
     },
     "description": {
         "message": "Privacy Badger schützt sie vor Trackern während Sie im Web surfen !"

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -3,13 +3,13 @@
         "message": "Add domain"
     },
     "badger_status_block": {
-        "message": "This tracker is BLOCKED, slide to unblock tracker or block cookies."
+        "message": "Blocked "
     },
     "badger_status_cookieblock": {
-        "message": "This tracker's cookies are blocked, slide to block or unblock tracker."
+        "message": "Blocked cookies from "
     },
     "badger_status_noaction": {
-        "message": "This domain is unblocked, slide to block entirely or block cookies."
+        "message": "Allowed "
     },
     "description": {
         "message": "Privacy Badger protects you from trackers as you surf the web!"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -3,13 +3,13 @@
         "message": "Ajouter un nom de domaine"
     },
     "badger_status_block": {
-        "message": "Ce traqueur est BLOQUÉ, glisser pour débloquer le traqueur ou bloquer les cookies."
+        "message": "Bloqué "
     },
     "badger_status_cookieblock": {
-        "message": "Ces cookies traqueurs sont bloqués, glisser pour bloquer ou débloquer les traqueurs."
+        "message": "Les cookies bloqués à partir de "
     },
     "badger_status_noaction": {
-        "message": "Ce nom de domaine est débloqué, glisser pour le bloquer entièrement ou pour bloquer les cookies."
+        "message": "Permis "
     },
     "description": {
         "message": "Privacy Badger vous protège des traqueurs lorsque vous surfez sur le web !"

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -3,13 +3,13 @@
         "message": "Aggiungi dominio"
     },
     "badger_status_block": {
-        "message": "Questo tracker è BLOCCATO, trascina per sbloccarlo o bloccarne i cookie."
+        "message": "Bloccato "
     },
     "badger_status_cookieblock": {
-        "message": "I cookie di questo tracker sono bloccati, trascina per bloccare o sbloccare il tracker."
+        "message": "Cookie bloccati da "
     },
     "badger_status_noaction": {
-        "message": "Questo dominio non è bloccato, trascina per bloccarlo totalmente o bloccarne i cookie."
+        "message": "Permesso "
     },
     "description": {
         "message": "Privacy Badger ti protegge dai tracker mentre navighi in rete!"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -3,13 +3,13 @@
         "message": "Voeg (derde) partij toe"
     },
     "badger_status_block": {
-        "message": "Deze tracker wordt GEBLOKKEERD. Beweeg de schuifbalkjes zodat Privacy Badger (derde) partijen blokkeert of niet."
+        "message": "Geblokkeerd "
     },
     "badger_status_cookieblock": {
-        "message": "Deze trackingcookies worden GEBLOKKEERD. Beweeg de schuifbalkjes zodat Privacy Badger trackingcookies blokkeert of niet."
+        "message": "Geblokkeerd cookies van "
     },
     "badger_status_noaction": {
-        "message": "Deze (derde) partij wordt doorgelaten. Beweeg de schuifbalkjes zodat Privacy Badger (derde) partijen blokkeert of niet."
+        "message": "Toegestaan "
     },
     "description": {
         "message": "Privacy Badger geeft u meer controle over het gevolgd worden op internet!"

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -3,13 +3,13 @@
         "message": "Lägg till domän"
     },
     "badger_status_block": {
-        "message": "Denna spanare är blockerad, dra för att häva blockering den eller blockera dess kakor."
+        "message": "Blockerad "
     },
     "badger_status_cookieblock": {
-        "message": "Denna spanares kakor är blockerade, dra för att blockera eller häva den för spanaren."
+        "message": "Blockerade cookies från "
     },
     "badger_status_noaction": {
-        "message": "Denna domän är inte blockerad, dra reglaget för att blockera helt eller bara kakorna."
+        "message": "Tillåten "
     },
     "description": {
         "message": "Privacy Badger skyddar dig mot spanare medan du surfar!"

--- a/src/popup.js
+++ b/src/popup.js
@@ -311,10 +311,14 @@ function _trim(str,max){
  */
 function _badgerStatusTitle(action , origin){ 
   
+  var status_block = i18n.getMessage("badger_status_block");
+  var status_cookieblock = i18n.getMessage("badger_status_cookieblock");
+  var status_noaction = i18n.getMessage("badger_status_noaction");
+
   var statusMap = {
-    block: "Blocked ",
-    cookieblock: "Blocked cookies from ",
-    noaction: "Allowed "
+    block:        status_block,
+    cookieblock:  status_cookieblock,
+    noaction:     status_noaction
   };
 
   return  statusMap[action] + origin ;

--- a/src/popup.js
+++ b/src/popup.js
@@ -281,7 +281,7 @@ function _addOriginHTML(origin, printable, action, flag, multiTLD) {
     multiText = " ("+multiTLD +" subdomains)";
   }
 
-  return printable + '<div ' + classText + '" data-origin="' + origin + '" tooltip="' + _badgerStatusTitle(action) + '" data-original-action="' + action + '"><div class="origin" >' +
+  return printable + '<div ' + classText + '" data-origin="' + origin + '" tooltip="' + _badgerStatusTitle(action, origin) + '" data-original-action="' + action + '"><div class="origin" >' +
      flagText + _trim(origin + multiText,30) + '</div>' + _addToggleHtml(origin, action) + '<div class="honeybadgerPowered tooltip" tooltip="'+ feedTheBadgerTitle + '"></div><img class="tooltipArrow" src="/icons/badger-tb-arrow.png"><div class="clear"></div><div class="tooltipContainer"></div></div>';
   
 }
@@ -309,19 +309,15 @@ function _trim(str,max){
  * @returns {string} The description, I18Ned
  * @private
  */
-function _badgerStatusTitle(action){
-  var prefix = "";
-  var status_block = i18n.getMessage("badger_status_block");
-  var status_cookieblock = i18n.getMessage("badger_status_cookieblock");
-  var status_noaction = i18n.getMessage("badger_status_noaction");
-
-  var statusMap = { 
-    block:        status_block,
-    cookieblock:  status_cookieblock,
-    noaction:     status_noaction
+function _badgerStatusTitle(action , origin){ 
+  
+  var statusMap = {
+    block: "Blocked ",
+    cookieblock: "Blocked cookies from ",
+    noaction: "Allowed "
   };
 
-  return prefix + statusMap[action];
+  return  statusMap[action] + origin ;
 }
 
 /**
@@ -568,8 +564,9 @@ function updateOrigin(event){
   var action = $elm.data('action');
   $switchContainer.removeClass('block cookieblock noaction').addClass(action);
   toggleBlockedStatus($clicker, action);
-  $clicker.attr('tooltip', _badgerStatusTitle(action));
-  $clicker.children('.tooltipContainer').html(_badgerStatusTitle(action));
+  var origin = $clicker.data('origin');
+  $clicker.attr('tooltip', _badgerStatusTitle(action, origin));
+  $clicker.children('.tooltipContainer').html(_badgerStatusTitle(action, origin));
   hideNoInitialBlockingLink();
 }
 


### PR DESCRIPTION
PB dropdown is too short and narrow #594

Changes in UI, now entire domain-name is showed as a tooltip thus solving the first problem of "dropdown being too narrow so domain-names get needlessly truncated and it becomes impossible to determine what 1st-level domain it belongs to."