### PR TITLE
Issue 640 fixed

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -89,6 +89,7 @@
 @@||cdn.discourse.org^$third-party
 @@||discovery.com^$third-party
 @@||disqus.com^$third-party
+@@||disquscdn.com^$third-party
 @@||dmcdn.net^$third-party
 @@||dmcdn.com^$third-party
 @@||screendoor.dobt.co^$third-party

--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -34,6 +34,7 @@
 @@||assetfiles.com^$third-party
 @@||authorize.net^$third-party
 @@||autoforums.com^$third-party
+@@||bandcamp.com^$third-party
 @@||bankrate.com^$third-party
 @@||betterttv.net^$third-party
 @@||bit.ly^$third-party


### PR DESCRIPTION
adds bandcamp and diqus cdns to cookie block list. 