### PR TITLE
Issue #619

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -484,3 +484,4 @@
 @@||cdnapi.kaltura.com^$third-party
 @@||cdnbakmi.kaltura.com^$third-party
 @@||www.kaltura.com^$third-party
+@@||assets.nflxext.com^$third-party


### PR DESCRIPTION
This is the fix for issue #619. Added assets.nflxext.com domain into the yellow list.