### PR TITLE
Block setting values to local storage if cookie blocking is enabled

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,7 @@
       "js": [
         "src/include.preload.js",
         "src/clobbercookie.js",
+        "src/clobberlocalstorage.js",
         "src/fingerprinting.js",
         "src/supercookie.js"
       ], 

--- a/src/clobbercookie.js
+++ b/src/clobbercookie.js
@@ -19,22 +19,34 @@
  * Runs in page content context. Injects a script that deletes cookies.
  * Communicates to webrequest.js to get orders if to delete cookies.
  */
+
+
+ function insertScript(text) {
+   var parent = document.documentElement,
+     script = document.createElement('script');
+
+   script.text = text;
+   script.async = false;
+
+   parent.insertBefore(script, parent.firstChild);
+   parent.removeChild(script);
+ }
+
+
+
+
+
+
 chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) {
   if (blocked) {
-    var code =
-      'var dummyCookie = "x=y";' +
-      'document.__defineSetter__("cookie", function(value) { return dummyCookie; });' +
-      'document.__defineGetter__("cookie", function() { return dummyCookie; });';
+    var code = '('+ function(){
+      var dummyCookie = "x=y";
+      document.__defineSetter__("cookie", function(value) { return dummyCookie; });
+      document.__defineGetter__("cookie", function() { return dummyCookie; });
+    } +')();'
 
-    var script = document.createElement('script');
-
-    script.appendChild(document.createTextNode(code));
-    (document.head || document.documentElement).appendChild(script);
-    script.parentNode.removeChild(script);
-
-    for (var prop in script) { delete script[prop]; }
-  }
-
+    insertScript(code);
+    }
   return true;
 });
 // Clobber local storage, using a function closure to keep the dummy private

--- a/src/clobberlocalstorage.js
+++ b/src/clobberlocalstorage.js
@@ -37,14 +37,10 @@
    parent.removeChild(script);
  }
 
-
-
-
-
 chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) {
   if (blocked) {
     var code =
-      '('+ function() { +
+      '('+ function() {
        window.localStorage.clear();
         var dummyLocalStorage = { };
           Object.defineProperty(window, "localStorage", {
@@ -63,17 +59,3 @@ chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) 
     }
   return true;
 });
-// Clobber local storage, using a function closure to keep the dummy private
-// (function() {
-//   var dummyLocalStorage = { };
-//   Object.defineProperty(window, "localStorage", {
-//     __proto__: null,
-//     configurable: false,
-//     get: function () {
-//       return dummyLocalStorage;
-//     },
-//     set: function (newValue) {
-//       // Do nothing
-//     }
-//   });
-// })();

--- a/src/clobberlocalstorage.js
+++ b/src/clobberlocalstorage.js
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Privacy Badger <https://www.eff.org/privacybadger>
+ * Copyright (C) 2014 Electronic Frontier Foundation
+ *
+ * Privacy Badger is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * Privacy Badger is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Runs in page content context. Injects a script that deletes cookies.
+ * Communicates to webrequest.js to get orders if to delete cookies.
+ */
+chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) {
+  if (blocked) {
+    var code =
+      '(function() {' +
+      ' window.localStorage.clear();' +
+      '  var dummyLocalStorage = { };' +
+      '    Object.defineProperty(window, "localStorage", {' +
+      '        __proto__: null,' +
+      '            configurable: false,' +
+      '                getItem: function () {' +
+      '                  return dummyLocalStorage;' +
+      '                 },' +
+      '                 setItem: function (newValue) {' +
+//Do Nothing
+      '                 }' +
+      '  });' +
+      '})();';
+
+    var script = document.createElement('script');
+
+    script.appendChild(document.createTextNode(code));
+    (document.head || document.documentElement).appendChild(script);
+    script.parentNode.removeChild(script);
+
+    for (var prop in script) { delete script[prop]; }
+  }
+
+  return true;
+});
+// Clobber local storage, using a function closure to keep the dummy private
+// (function() {
+//   var dummyLocalStorage = { };
+//   Object.defineProperty(window, "localStorage", {
+//     __proto__: null,
+//     configurable: false,
+//     get: function () {
+//       return dummyLocalStorage;
+//     },
+//     set: function (newValue) {
+//       // Do nothing
+//     }
+//   });
+// })();

--- a/src/clobberlocalstorage.js
+++ b/src/clobberlocalstorage.js
@@ -43,7 +43,7 @@ chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) 
       '('+ function() {
        window.localStorage.clear();
         var dummyLocalStorage = { };
-          Object.defineProperty(window, "localStorage", {
+          Object.defineProperty(document, "localStorage", {
               __proto__: null,
                   configurable: false,
                       getItem: function () {

--- a/src/clobberlocalstorage.js
+++ b/src/clobberlocalstorage.js
@@ -41,19 +41,13 @@ chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) 
   if (blocked) {
     var code =
       '('+ function() {
-       window.localStorage.clear();
-        var dummyLocalStorage = { };
-          Object.defineProperty(document, "localStorage", {
-              __proto__: null,
-                  configurable: false,
-                      getItem: function () {
-                        return dummyLocalStorage;
-                    },
-                       setItem: function (newValue) {
-                           //Do Nothing
-                       }
-        });
-    }+')()';
+          window.localStorage.getItem = function () {
+               return {};
+           }
+          window.localStorage.setItem=function (newValue) {
+              //doNothing
+                       };
+        } +')()';
 
     insertScript(code);
     }

--- a/src/clobberlocalstorage.js
+++ b/src/clobberlocalstorage.js
@@ -22,20 +22,20 @@
 chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) {
   if (blocked) {
     var code =
-      '(function() {' +
-      ' window.localStorage.clear();' +
-      '  var dummyLocalStorage = { };' +
-      '    Object.defineProperty(window, "localStorage", {' +
-      '        __proto__: null,' +
-      '            configurable: false,' +
-      '                getItem: function () {' +
-      '                  return dummyLocalStorage;' +
-      '                 },' +
-      '                 setItem: function (newValue) {' +
-//Do Nothing
-      '                 }' +
-      '  });' +
-      '})();';
+      '('+ function() { +
+       window.localStorage.clear();
+        var dummyLocalStorage = { };
+          Object.defineProperty(window, "localStorage", {
+              __proto__: null,
+                  configurable: false,
+                      getItem: function () {
+                        return dummyLocalStorage;
+                    },
+                       setItem: function (newValue) {
+                           //Do Nothing
+                       }
+        });
+    }+')()';
 
     var script = document.createElement('script');
 

--- a/src/clobberlocalstorage.js
+++ b/src/clobberlocalstorage.js
@@ -19,6 +19,28 @@
  * Runs in page content context. Injects a script that deletes cookies.
  * Communicates to webrequest.js to get orders if to delete cookies.
  */
+
+ /**
+  * Insert script into page
+  *
+  * @param {String} text The script to insert into the page
+ */
+
+ function insertScript(text) {
+   var parent = document.documentElement,
+     script = document.createElement('script');
+
+   script.text = text;
+   script.async = false;
+
+   parent.insertBefore(script, parent.firstChild);
+   parent.removeChild(script);
+ }
+
+
+
+
+
 chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) {
   if (blocked) {
     var code =
@@ -37,15 +59,8 @@ chrome.runtime.sendMessage({checkLocation:document.location}, function(blocked) 
         });
     }+')()';
 
-    var script = document.createElement('script');
-
-    script.appendChild(document.createTextNode(code));
-    (document.head || document.documentElement).appendChild(script);
-    script.parentNode.removeChild(script);
-
-    for (var prop in script) { delete script[prop]; }
-  }
-
+    insertScript(code);
+    }
   return true;
 });
 // Clobber local storage, using a function closure to keep the dummy private


### PR DESCRIPTION
Work in progress to #663 

Based of clobbercookie.js

If cookie blocking is enabled, it will clear Local Storage and thens block the api.

I'm not sure if it is possible to guarantee, that injected script runs before other scripts.

I have a test case here: https://github.com/zmanian/LocalStoragePrivacyBadgerTest 