### PR TITLE
Issue#578

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -491,3 +491,4 @@
 @@||www.kaltura.com^$third-party
 @@||assets.nflxext.com^$third-party
 @@||assets.ubuntu.com^$third-party
+@@||y3.analytics.yahoo.com^$third-party

--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -490,3 +490,4 @@
 @@||cdnbakmi.kaltura.com^$third-party
 @@||www.kaltura.com^$third-party
 @@||assets.nflxext.com^$third-party
+@@||assets.ubuntu.com^$third-party

--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -484,3 +484,4 @@
 @@||cdnapi.kaltura.com^$third-party
 @@||cdnbakmi.kaltura.com^$third-party
 @@||www.kaltura.com^$third-party
+@@||assets.nflxext.com^$third-party

--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -492,3 +492,5 @@
 @@||assets.nflxext.com^$third-party
 @@||assets.ubuntu.com^$third-party
 @@||y3.analytics.yahoo.com^$third-party
+@@||a.disquscdn.com^$third-party
+@@||uploads.disquscdn.com^$third-party


### PR DESCRIPTION
This is the fix for issue #578. Added the two domains a.disquscdn.com and uploads.disquscdn into the yellowlist.