### PR TITLE
Update chrome, chromedriver for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
 install:
+  - sudo apt-get update
   - sudo apt-get -qq install xvfb python-virtualenv
   - npm install
 before_script:

--- a/setup_travis.sh
+++ b/setup_travis.sh
@@ -10,8 +10,14 @@ else
     elif [ $machine = "i686" ] ; then 
         bits="32"; 
     fi;
-    version="2.12"
+    version="2.20"
     wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/$version/chromedriver_linux$bits.zip"
     sudo unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
     sudo chmod a+x /usr/local/bin/chromedriver
 fi
+
+# Install latest stable Chrome
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+sudo apt-get update
+sudo apt-get install google-chrome-stable


### PR DESCRIPTION
Regression tests run locally, but fail on Travis CI due to flakey Chromedriver behavior. This PR updates Chromedriver from v.2.12 to v.2.20. Because that version of Chromedriver won't run with whatever version of Chromium lives in the testbed, setup_travis.py installs the latest stable version of Chrome too.

Also: apt-get could not always find python-virtualenv. I added an apt-get update before in .travis.yml, which appears to solve the issue.