### PR TITLE
Add securesuite.co.uk to cookieblock list

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -370,6 +370,7 @@
 @@||salesforce.com^$third-party
 @@||salsalabs.com^$third-party
 @@||sbnation.com^$third-party
+@@||securesuite.co.uk^$third-party
 @@||securitymetrics.com^$third-party
 @@||seeclickfix.com^$third-party
 @@||sgizmo.com^$third-party


### PR DESCRIPTION
This is required for "Verified by Visa" and "Mastercard Securecode" in the UK.

This should fix https://github.com/EFForg/privacybadgerfirefox/issues/212.