### PR TITLE
Check if PB is activated and social widget replacement is enabled before replacing widgets.

### DIFF
--- a/src/socialwidgets.js
+++ b/src/socialwidgets.js
@@ -318,9 +318,11 @@ function replaceIndividualButton(tracker) {
 */
 function getTrackerData(callback) {
 	chrome.runtime.sendMessage({checkReplaceButton:document.location}, function(response) {
-		var trackers = response.trackers;
-		var trackerButtonsToReplace = response.trackerButtonsToReplace;
-		callback(trackers, trackerButtonsToReplace);
+	  if (response){
+	    var trackers = response.trackers;
+	    var trackerButtonsToReplace = response.trackerButtonsToReplace;
+	    callback(trackers, trackerButtonsToReplace);
+	  }
 	});
 }
 
@@ -340,4 +342,11 @@ function unblockTracker(buttonUrls, callback) {
 	chrome.runtime.sendMessage(request, callback);
 }
 
-initialize();
+chrome.runtime.sendMessage({
+  checkSocialWidgetReplacementEnabled: true
+}, function (checkSocialWidgetReplacementEnabled) {
+  if (!checkSocialWidgetReplacementEnabled) {
+    return;
+  }
+  initialize();
+});

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -735,7 +735,6 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
       var socialWidgetBlockList = getSocialWidgetBlockList();
       sendResponse(socialWidgetBlockList);
     }
-
   } else if (request.unblockSocialWidget) {
     var socialWidgetUrls = request.buttonUrls;
     unblockSocialWidgetOnTab(sender.tab.id, socialWidgetUrls);
@@ -758,6 +757,8 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   } else if (request.checkEnabledAndThirdParty) {
     var pageHost = extractHostFromURL(sender.url);
     sendResponse(Utils.isPrivacyBadgerEnabled(tabHost) && isThirdParty(pageHost, tabHost));
+  } else if (request.checkSocialWidgetReplacementEnabled) {
+    sendResponse(Utils.isPrivacyBadgerEnabled(tabHost) && Utils.isSocialWidgetReplacementEnabled());
   }
 
 });


### PR DESCRIPTION
It seems the social widget replacement code does not check if PB is enabled for the current page and if widget replacement is enabled in the PB options.

This should add a check before injecting the content script that replaces the widgets. Also checks the `response` object in the social widget callback which causes the relevant issue #726.