### PR TITLE
Reduce the test fragility by waiting some time to make sure the dynamic content is loaded.

### DIFF
--- a/tests/selenium/breakage_test.py
+++ b/tests/selenium/breakage_test.py
@@ -15,11 +15,11 @@ class Test(pbtest.PBSeleniumTest):
     add Reddit comments etc."""
 
     def test_should_load_eff_org(self):
-        self.driver.get("https://www.eff.org")
+        self.load_url("https://www.eff.org")
         WebDriverWait(self.driver, 10).until(EC.title_contains("Electronic Frontier Foundation"))
 
     def test_should_search_google(self):
-        self.driver.get("https://www.google.com/")
+        self.load_url("https://www.google.com/")
         qry_el = self.driver.find_element_by_name("q")
         qry_el.send_keys("EFF")  # search term
         qry_el.submit()

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -28,7 +28,7 @@ class CookieTest(pbtest.PBSeleniumTest):
     """Basic test to make sure the PB doesn't mess up with the cookies."""
 
     def assert_pass_opera_cookie_test(self, url, test_name):
-        self.driver.get(url)
+        self.load_url(url)
         self.assertEqual("PASS",
              self.js("return document.getElementById('result').innerHTML"),
              "Cookie test failed: %s" % test_name)
@@ -49,21 +49,21 @@ class CookieTest(pbtest.PBSeleniumTest):
 	# fixme: check for chrome settings for third party cookies?
 
 	# load the first site with the third party code that reads and writes a cookie
-        self.driver.get( PB_CHROME_SITE1_URL )
+        self.load_url( PB_CHROME_SITE1_URL )
 	window_utils.close_windows_with_url( self.driver, PB_CHROME_FR_URL )
 	self.load_pb_ui( PB_CHROME_SITE1_URL )
 	self.get_tracker_state()
 	self.assertTrue( self.nonTrackers.has_key( PB_CHROME_THIRD_PARTY_TRACKER ) )
 
 	# go to second site
-        self.driver.get( PB_CHROME_SITE2_URL )
+        self.load_url( PB_CHROME_SITE2_URL )
 	window_utils.close_windows_with_url( self.driver, PB_CHROME_SITE1_URL )
 	self.load_pb_ui( PB_CHROME_SITE2_URL )
 	self.get_tracker_state()
 	self.assertTrue( self.nonTrackers.has_key( PB_CHROME_THIRD_PARTY_TRACKER ) )
 
 	# go to third site
-        self.driver.get( PB_CHROME_SITE3_URL )
+        self.load_url( PB_CHROME_SITE3_URL )
 	window_utils.close_windows_with_url( self.driver, PB_CHROME_SITE2_URL )
 	self.load_pb_ui( PB_CHROME_SITE3_URL )
 	self.get_tracker_state()
@@ -73,7 +73,7 @@ class CookieTest(pbtest.PBSeleniumTest):
 	# it can take a long time for the UI to be updated, so retry a number of
 	# times before giving up. See bug #702.
 	print "this is checking for a dnt file at a site without https, so we'll just have to wait for the connection to timeout before we proceed"
-        self.driver.get( PB_CHROME_SITE1_URL )
+        self.load_url( PB_CHROME_SITE1_URL )
 	window_utils.close_windows_with_url( self.driver, PB_CHROME_SITE3_URL )
 	for i in range(60):
 		self.load_pb_ui( PB_CHROME_SITE1_URL )
@@ -112,7 +112,7 @@ class CookieTest(pbtest.PBSeleniumTest):
 	button = self.driver.find_element_by_id("newwindowbutton")
 	button.click()
 	window_utils.switch_to_window_with_url( self.driver, "about:blank" )
-	self.driver.get(PB_CHROME_PU_URL)
+	self.load_url(PB_CHROME_PU_URL)
 
 	# use the new convenience function to get the popup populated with status information for the correct url
 	window_utils.switch_to_window_with_url( self.driver, PB_CHROME_PU_URL )

--- a/tests/selenium/localstorage_test.py
+++ b/tests/selenium/localstorage_test.py
@@ -45,7 +45,7 @@ class LocalStorageTest(pbtest.PBSeleniumTest):
             self.assertEqual(PB_POLICY_HASH_LEN, len(v))  # check hash length
 
     def test_should_init_local_storage_entries(self):
-        self.driver.get(pbtest.PB_CHROME_BG_URL)
+        self.load_url(pbtest.PB_CHROME_BG_URL)
         js = self.js
         self.check_policy_download()
         self.assertEqual(js("return localStorage.whitelistUrl"),

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -23,8 +23,8 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
             (By.CSS_SELECTOR, css_selector)))
 
     def test_page_title(self):
-        self.driver.get(pbtest.PB_CHROME_BG_URL)  # load a dummy page
-        self.driver.get(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
+        self.load_url(pbtest.PB_CHROME_BG_URL)  # load a dummy page
+        self.load_url(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
         localized_title = self.js('return i18n.getMessage("options_title")')
         try:
             WebDriverWait(self.driver, 3).until(EC.title_contains(localized_title))

--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -10,6 +10,7 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from time import sleep
 
 # PB_EXT_BG_URL_BASE = "chrome-extension://pkehgijcmpdhfbdbbnkijodmdjhbjlgp/"
 PB_EXT_BG_URL_BASE = "chrome-extension://mcgekeccgjgcmhnhbabplanchdogjcnh/"
@@ -32,6 +33,11 @@ class PBSeleniumTest(unittest.TestCase):
             self.vdisplay.start()
         self.driver = self.get_chrome_driver()
         self.js = self.driver.execute_script
+
+    def load_url(self, url, wait_on_site=0):
+        """Load a URL and wait before returning."""
+        self.driver.get(url)
+        sleep(wait_on_site)
 
     def get_extension_path(self):
         """Return the path to the extension to be tested."""

--- a/tests/selenium/qunit_test.py
+++ b/tests/selenium/qunit_test.py
@@ -14,8 +14,8 @@ class Test(pbtest.PBSeleniumTest):
         # Otherwise, we ran into a race condition where Qunit runs (& fails)
         # while chrome.extension is undefined.
         # Probably related to Chromium bugs 129181 & 132148
-        self.driver.get(pbtest.PB_CHROME_BG_URL)  # load a dummy page
-        self.driver.get(PB_CHROME_QUNIT_TEST_URL)
+        self.load_url(pbtest.PB_CHROME_BG_URL)  # load a dummy page
+        self.load_url(PB_CHROME_QUNIT_TEST_URL)
         failed = self.txt_by_css("#qunit-testresult > span.failed")
         passed = self.txt_by_css("#qunit-testresult > span.passed")
         total = self.txt_by_css("#qunit-testresult > span.total")

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -11,27 +11,31 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
 
     def has_supercookies(self, origin):
         """Check if the given origin has supercookies in PB's localStorage."""
-        self.driver.get(pbtest.PB_CHROME_BG_URL)
+        self.load_url(pbtest.PB_CHROME_BG_URL)
         get_sc_domains_js = "return localStorage.getItem('supercookieDomains')"
         supercookieDomains = json.loads(self.js(get_sc_domains_js))
         return origin in supercookieDomains
 
     # localStorage (ls) tests
     def test_should_detect_ls_of_third_party_frame(self):
-        self.driver.get("https://jsfiddle.net/uon507ut/embedded/result/")
+        self.load_url("https://jsfiddle.net/uon507ut/embedded/result/",
+                      wait_on_site=10)
         self.assertTrue(self.has_supercookies("rawgit.com"))
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):
-        self.driver.get("https://jsfiddle.net/21za32ve/1/embedded/result/")
+        self.load_url("https://jsfiddle.net/21za32ve/1/embedded/result/",
+                      wait_on_site=10)
         self.assertFalse(self.has_supercookies("rawgit.com"))
 
     def test_should_not_detect_first_party_ls(self):
-        self.driver.get("https://rawgit.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html")  # noqa
+        self.load_url("https://rawgit.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html",  # noqa
+                        wait_on_site=10)
         self.assertFalse(self.has_supercookies("rawgit.com"))
 
     def test_should_not_detect_ls_of_third_party_script(self):
         # a third-party script included by the top page (not a 3rd party frame)
-        self.driver.get("https://jsfiddle.net/gzehyh92/embedded/result/")
+        self.load_url("https://jsfiddle.net/gzehyh92/embedded/result/",
+                      wait_on_site=10)
         self.assertFalse(self.has_supercookies("rawgit.com"))
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add some wait time on test pages with third-party frames to make sure they're loaded properly. Add a convenience method to load URLs.

Here's an example flaky test, failed after removing comments!
https://travis-ci.org/gunesacar/privacybadgerchrome/builds/110258308