### PR TITLE
Wait longer for the QUnit test results.

### DIFF
--- a/tests/selenium/pbtest.py
+++ b/tests/selenium/pbtest.py
@@ -16,6 +16,7 @@ from time import sleep
 PB_EXT_BG_URL_BASE = "chrome-extension://mcgekeccgjgcmhnhbabplanchdogjcnh/"
 PB_CHROME_BG_URL = PB_EXT_BG_URL_BASE + "_generated_background_page.html"
 PB_CHROME_OPTIONS_PAGE_URL = PB_EXT_BG_URL_BASE + "skin/options.html"
+SEL_DEFAULT_WAIT_TIMEOUT = 30
 
 
 class PBSeleniumTest(unittest.TestCase):
@@ -50,12 +51,12 @@ class PBSeleniumTest(unittest.TestCase):
             exts = glob("../../*.crx")  # get matching files
             return max(exts, key=os.path.getctime) if exts else ""
 
-    def txt_by_css(self, css_selector):
+    def txt_by_css(self, css_selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
         """Find an element by CSS selector and return it's text."""
-        return self.find_el_by_css(css_selector).text
+        return self.find_el_by_css(css_selector, timeout).text
 
-    def find_el_by_css(self, css_selector):
-        return WebDriverWait(self.driver, 30).until(
+    def find_el_by_css(self, css_selector, timeout=SEL_DEFAULT_WAIT_TIMEOUT):
+        return WebDriverWait(self.driver, timeout).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, css_selector)))
 
     def get_chrome_driver(self):

--- a/tests/selenium/qunit_test.py
+++ b/tests/selenium/qunit_test.py
@@ -3,6 +3,7 @@
 
 import unittest
 import pbtest
+from selenium.common.exceptions import TimeoutException
 
 PB_CHROME_QUNIT_TEST_URL = pbtest.PB_EXT_BG_URL_BASE + "tests/index.html"
 
@@ -16,7 +17,10 @@ class Test(pbtest.PBSeleniumTest):
         # Probably related to Chromium bugs 129181 & 132148
         self.load_url(pbtest.PB_CHROME_BG_URL)  # load a dummy page
         self.load_url(PB_CHROME_QUNIT_TEST_URL)
-        failed = self.txt_by_css("#qunit-testresult > span.failed")
+        try:
+            failed = self.txt_by_css("#qunit-testresult > span.failed", timeout=120)
+        except TimeoutException as exc:
+            self.fail("Cannot find the results of QUnit tests %s" % exc)
         passed = self.txt_by_css("#qunit-testresult > span.passed")
         total = self.txt_by_css("#qunit-testresult > span.total")
         print "User agent:", self.txt_by_css("#qunit-userAgent")


### PR DESCRIPTION
Selenium based QUnit tests timeout and fail the CI every now and then (e.g. [1](https://travis-ci.org/EFForg/privacybadgerchrome/builds/109954744), [2](https://travis-ci.org/gunesacar/privacybadgerchrome/builds/69709898), [3](https://travis-ci.org/EFForg/privacybadgerchrome/builds/109994005)).
Introduce a timeout value for the helper functions. Wait 120 seconds for the QUnit test suite to finish.

