### PR TITLE
closes gh-756

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -511,3 +511,6 @@
 @@||www.img-bahn.de^$third-party
 @@||seatme.yelp.com^$third-party
 @@||firstlook.org^$third-party
+@@||tkx2-prod.anvato.net^$third-party
+@@||up.anv.bz^$third-party
+@@||mcp-media5.anvato.net^$third-party


### PR DESCRIPTION
Add to cookieblocklist:
* tkx2-prod.anvato.net
* up.anv.bz
* mcp-media5.anvato.net

I'm not sure if these domains meet the yellowlist criteria as discussed in #756 if they don't feel free to close this PR.

Also I noticed that the entries in `doc/sample_cookieblocklist.txt` were mostly in alphabetical order, but also new entries were just appended to the list. So I just appended these. 