### PR TITLE
Refactor domain search on options page

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -429,20 +429,32 @@ function refreshFilterPage() {
  * @param event Input event triggered by user.
  */
 function filterTrackingDomains(event) {
-  var searchText = $('#trackingDomainSearch').val().toLowerCase();
-  var allTrackingDomains = getOriginsArray();
+  var initialSearchText = $('#trackingDomainSearch').val().toLowerCase();
 
-  var filteredTrackingDomains = [];
-  for (var i = 0; i < allTrackingDomains.length; i++) {
-    var trackingDomain = allTrackingDomains[i];
-
-    // Ignore domains that do not contain search text.
-    if (trackingDomain.toLowerCase().indexOf(searchText) !== -1) {
-      filteredTrackingDomains.push(trackingDomain);
+  // Wait a short period of time and see if search text has changed.
+  // If so it means user is still typing so hold off on filtering.
+  var timeToWait = 500;
+  setTimeout(function() {
+    // Check search text.
+    var searchText = $('#trackingDomainSearch').val().toLowerCase();
+    if (searchText !== initialSearchText) {
+      return;
     }
-  }
 
-  showTrackingDomains(filteredTrackingDomains);
+    // Filter tracking domains based on search text.
+    var allTrackingDomains = getOriginsArray();
+    var filteredTrackingDomains = [];
+    for (var i = 0; i < allTrackingDomains.length; i++) {
+      var trackingDomain = allTrackingDomains[i];
+
+      // Ignore domains that do not contain search text.
+      if (trackingDomain.toLowerCase().indexOf(searchText) !== -1) {
+        filteredTrackingDomains.push(trackingDomain);
+      }
+    }
+
+    showTrackingDomains(filteredTrackingDomains);
+  }, timeToWait);
 }
 
 /**


### PR DESCRIPTION
This ports changes from the Firefox version to add a short delay before filtering tracking domains on the options page while user types.

[Pull request](https://github.com/EFForg/privacybadgerfirefox/pull/745) for the same changes to the Firefox version.