### PR TITLE
add bandcamp cdn to cookie block list

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -516,3 +516,4 @@
 @@||tkx2-prod.anvato.net^$third-party
 @@||up.anv.bz^$third-party
 @@||mcp-media5.anvato.net^$third-party
+@@||bcbits.com^$third-party


### PR DESCRIPTION
bcbits.com seems to be bandcamp's CDN and is getting blocked for me. I had manually overridden some of the domains it uses, but it uses random subdomains p1.bcbits.com, f1.bcbits.com, s1.bcbits.com which mean that occasionally a bandcamp site will still randomly break.