### PR TITLE
Fix issues with tutorial overlay changes

### DIFF
--- a/skin/popup.css
+++ b/skin/popup.css
@@ -226,30 +226,17 @@ font-size: 16px;
   position: fixed;
   z-index: 100;
   background-color: #000;
-<<<<<<< HEAD
-  opacity: .85;
-  height: 92%;
-=======
   opacity: .9;
   height: 100%;
->>>>>>> 5c622df389901cfc866845a0b1785187c408a508
   width: 370px;
   color: #fff;
   text-align: left;
   padding: 15px;
-<<<<<<< HEAD
-  margin-top: 5px;
-  margin-right: 20px;
-  margin-bottom: 20px;
-=======
-  margin-right: 20px;
->>>>>>> 5c622df389901cfc866845a0b1785187c408a508
   font-size: 14px;
 }
 #fittslaw {
   position: relative;
   float: right;
-  right: 0px;
   padding: 13px;
   cursor: pointer;
 }

--- a/skin/popup.html
+++ b/skin/popup.html
@@ -25,11 +25,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link type="text/css" href="/lib/jquery-ui/css/smoothness/jquery-ui-1.10.4.custom.css" rel="stylesheet" />
 <link type="text/css" media="screen" href="/skin/popup.css" rel="stylesheet" />
-<link type="text/css" media="screen" href="/skin/toggle-switch.css" rel="stylesheet"/>
+<link type="text/css" media="screen" href="/skin/toggle-switch.css" rel="stylesheet" />
 <script type="text/javascript" src="/lib/jquery-ui/js/jquery-1.10.2.js"></script>
 <script type="text/javascript" src="/lib/jquery-ui/js/jquery-ui-1.10.4.custom.min.js"></script>
 <script type="text/javascript" src="/src/popup.js"></script>
-<script type="text/javascript" src="/skin/firstRun.js"></script>
 <script type="text/javascript" src="/lib/i18n.js"></script>
 </head>
 <body id="main">
@@ -38,24 +37,23 @@
       <line x1="5" y1="5" x2="35" y2="35" style="stroke:rgb(255,255,255);stroke-width:3;fill:transparent"/>
       <line x1="5" y1="35" x2="35" y2="5" style="stroke:rgb(255,255,255);stroke-width:3;fill:transparent"/>
     </svg>
-  <p class="i18n_intro_text"></p>
-  <br>
-  <div id="firstRun">
-    <p class="i18n_first_run_text"></p>
+    <p class="i18n_intro_text"></p>
+    <br>
+    <div id="firstRun">
+      <p class="i18n_first_run_text"></p>
+    </div>
   </div>
-</div>
-<div id="overlay">
+  <div id="overlay">
     <h1 id="report_title" class="i18n_report_title"></h1>
-      <span id="report_close" class="i18n_report_close"></span>
-      <p id="report_text" class="i18n_report_text"></p>
-        <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
-        <textarea id="error_input" name="error_input" maxlength="300" placeholder="What's wrong?"></textarea>
-        <button id="report_button" class="i18n_report_button"></button>
-        <button id="report_cancel" class="i18n_report_cancel"></button>
-        <span id="report_success" class="i18n_report_success hidden"></span>
-        <span id="report_fail" class="i18n_report_fail hidden"></span>
-        <p id="report_terms" class="i18n_report_terms"></p>
-
+    <span id="report_close" class="i18n_report_close"></span>
+    <p id="report_text" class="i18n_report_text"></p>
+    <label id="report_label" for="error_input" class="i18n_report_input_label"></label>
+    <textarea id="error_input" name="error_input" maxlength="300" placeholder="What's wrong?"></textarea>
+    <button id="report_button" class="i18n_report_button"></button>
+    <button id="report_cancel" class="i18n_report_cancel"></button>
+    <span id="report_success" class="i18n_report_success hidden"></span>
+    <span id="report_fail" class="i18n_report_fail hidden"></span>
+    <p id="report_terms" class="i18n_report_terms"></p>
   </div>
 <div id="mustReloadMsg" style="display:none"><span class="i18n_new_filters_added"></span></div>
 
@@ -67,7 +65,7 @@
 </div>
 <div id="blockedResourcesContainer">
   <p id="pbInstructions"> <span class="i18n_pb_detected"></span> <span id='number_trackers'></span> <span class="i18n_popup_instructions"></span></p>
-    <p id="noBlockingLink"><!-- TODO: tooltip into _locales --><a href="https://www.eff.org/privacybadger#how_is_it_different" target="_blank" tabindex="-1" title="Blocking starts only if privacy badger detects an attempt to track you across multiple websites. Domains listed below did not tracked you yet. It is either because they had no chance yet (you did not browsed enough) or because they do not engage in tracking. "><span class=i18n_popup_noblocked"></span></a></p>
+    <p id="noBlockingLink"><!-- TODO: tooltip into _locales --><a href="https://www.eff.org/privacybadger#how_is_it_different" target="_blank" tabindex="-1" title="Blocking starts only if privacy badger detects an attempt to track you across multiple websites. Domains listed below did not tracked you yet. It is either because they had no chance yet (you did not browsed enough) or because they do not engage in tracking. "><span class="i18n_popup_noblocked"></span></a></p>
   <div class="spacer"></div>
   <div id="blockedResources"><span class="options_loading"></span></div>
 </div>


### PR DESCRIPTION
This fixes some of the issues with #766. It looks like including *firstRun.js* in *popup.html* was causing issues with the tooltips and sliders. There are still other issues because the trackers link in the popup isn't fixed yet and the merge conflict in *popup.css* needs to be cleaned up.