### PR TITLE
Yellowlist c.tadst.com

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -416,6 +416,7 @@
 @@||surveymonkey.com^$third-party
 @@||syracuse.com^$third-party
 @@||public.tableausoftware.com^$third-party
+@@||c.tadst.com^$third-party
 @@||targetimg1.com^$third-party
 @@||targetimg2.com^$third-party
 @@||technorati.com^$third-party


### PR DESCRIPTION
Fixing https://www.timeanddate.com/time/dst/history.html