### PR TITLE
Add build.origami.ft.com to the yellow-list

### DIFF
--- a/doc/sample_cookieblocklist.txt
+++ b/doc/sample_cookieblocklist.txt
@@ -129,6 +129,7 @@
 @@||financialcontent.com^$third-party
 @@||findnsave.com^$third-party
 @@||frz.io^$third-party
+@@||build.origami.ft.com^$third-party
 @@||fz.io^$third-party
 @@||fzcdn.net^$third-party
 @@||hello.firefox.com^$third-party


### PR DESCRIPTION
I found that the domain was being blocked by Privacy Badger on https://cdn.polyfill.io/v2/docs/ for example.