### PR TITLE
Fix crash when closing options page

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -165,10 +165,8 @@ function unloadOptions()
   FilterNotifier.removeListener(onFilterChange);
 }
 
-function onFilterChange(action, item, param1, param2)
-{
-    syncUISelections();
-    refreshFilterPage();
+function onFilterChange(action, item, param1, param2) {
+  syncSettings();
 }
 
 function addWhitelistDomain(event)
@@ -443,6 +441,10 @@ function registerToggleHandlers(element) {
     },
     stop: function(event, ui) {
       $(ui.handle).css('margin-left', -16 * ui.value + 'px');
+
+      // Save change for origin.
+      var origin = radios.filter('[value=' + ui.value + ']')[0].name;
+      syncSettings(origin);
     },
   }).appendTo(element);
 
@@ -496,19 +498,6 @@ function hideTooltip(event){
   $elm.on('mouseenter',function(){clearTimeout(hideTipTimer)});
 }
 
-function syncSettingsDict(settingsDict) {
-  // track whether reload is needed: only if things are being unblocked
-  var reloadNeeded = false;
-  // we get the blocked data again in case anything changed, but the user's change when
-  // closing a page is authoritative and we should sync the real state to that
-  for (var origin in settingsDict) {
-    var userAction = settingsDict[origin];
-    saveAction(userAction, origin)
-  }
-  console.log("Finished syncing. Now refreshing options page.");
-  // the options page needs to be refreshed to display current results
-  refreshFilterPage();
-}
 function getCurrentClass(elt) {
   if ($(elt).hasClass("block"))
     return "block";
@@ -518,39 +507,58 @@ function getCurrentClass(elt) {
     return "noaction";
 }
 
-function buildSettingsDict() {
-  var settingsDict = {};
-  $('.clicker').each(function() {
+/**
+ * Fetches origins that need to be synced.
+ *
+ * @param originToCheck {String} Origin to check for changes, optional. If null,
+ *                               all origins are checked.
+ * @return {Object}
+ */
+function getOriginsToSync(originToCheck) {
+  // Function to add origin if set by user and changed.
+  _fetchOrigins = function() {
     var origin = $(this).attr("data-origin");
-    if ($(this).hasClass("userset") && getCurrentClass(this) != $(this).attr("data-original-action")) {
-      // todo: DRY; same as code above, break out into helper
-      if ($(this).hasClass("block"))
-        settingsDict[origin] = "block";
-      else if ($(this).hasClass("cookieblock"))
-        settingsDict[origin] = "cookieblock";
-      else
-        settingsDict[origin] = "noaction";
+    var userset = $(this).hasClass("userset");
+    var changed = getCurrentClass(this) != $(this).attr("data-original-action");
+    if (userset && changed) {
+      origins[origin] = getCurrentClass(this);
     }
-  });
-  return settingsDict;
+  }
+
+  // Check each element for any changes by user.
+  var origins = {};
+  if (originToCheck) {
+    $('.clicker[data-origin="' + originToCheck + '"]').each(_fetchOrigins);
+  } else {
+    $('.clicker').each(_fetchOrigins);
+  }
+
+  return origins;
 }
 
-// syncs the user-selected cookie blocking options, etc
-function syncUISelections() {
-  var settingsDict = buildSettingsDict();
-  console.log("Sync of userset options: " + JSON.stringify(settingsDict));
-  syncSettingsDict(settingsDict);
+/**
+ * Syncs settings for origins changed by user.
+ *
+ * @param originToCheck {String} Origin to check for changes, optional. If null,
+ *                               all origins are checked.
+ */
+function syncSettings(originToCheck) {
+  var originsToSync = getOriginsToSync(originToCheck);
+  console.log("Syncing userset options: " + JSON.stringify(originsToSync));
+
+  // Save new action for updated origins.
+  for (var origin in originsToSync) {
+    var userAction = originsToSync[origin];
+    saveAction(userAction, origin);
+  }
+  console.log("Finished syncing.");
+
+  // Options page needs to be refreshed to display current results.
+  refreshFilterPage();
 }
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function() {
   chrome.tabs.getSelected(null, function(tab) {
-    refreshFilterPage(tab.id);
+    refreshFilterPage();
   });
 });
-window.addEventListener('unload', function() {
-  console.log("Starting to unload options page");
-  syncUISelections();
-  console.log("unloaded options page");
-});
-
-


### PR DESCRIPTION
This fixes #799. Changes are saved as soon as they are made instead of waiting until the options page is closed. There are further improvements that can be made but I wanted to submit this now as I'll be busy the next couple weeks.

This also fixes an unrelated issue where a change is made to an origin, the list of origins are filtered, and then closing the options page doesn't save the change. This is because the changes to save are determined by checking the displayed list of origins.