### PR TITLE
Use Ubuntu 14.04 for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
+sudo: required
 language: python
+os: linux
+dist: trusty
 python:
   - "2.7"
+addons:
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 install:
   - sudo apt-get update
-  - sudo apt-get -qq install xvfb python-virtualenv
+  - sudo apt-get -qq install python-virtualenv
   - npm install
 before_script:
   - ./scripts/setup_travis.sh

--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -4,20 +4,8 @@
 if [ -x /usr/local/bin/chromedriver ]; then
     echo "You already have ChromeDriver installed. Skipping this step."
 else
-    machine=`uname -m`
-    if [ $machine = "x86_64" ] ; then 
-        bits="64"; 
-    elif [ $machine = "i686" ] ; then 
-        bits="32"; 
-    fi;
-    version="2.20"
-    wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/$version/chromedriver_linux$bits.zip"
+    latest_version=$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)
+    wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${latest_version}/chromedriver_linux64.zip"
     sudo unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
     sudo chmod a+x /usr/local/bin/chromedriver
 fi
-
-# Install latest stable Chrome
-wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-sudo apt-get update
-sudo apt-get install google-chrome-stable

--- a/tests/run_selenium_tests.sh
+++ b/tests/run_selenium_tests.sh
@@ -24,5 +24,5 @@ export BROWSER_BIN=""   # Path to the browser binary. Optional.
 # If empty, Selenium will pick the default binary for the selected browser.
 # To run tests with Chromium (instead of default Google Chrome) export BROWSER_BIN="/usr/bin/chromium-browser"
 export ENABLE_XVFB=1    # run the tests headless using Xvfb. Set 0 to disable
-py.test -s selenium  # autodiscover and run the tests
+py.test -s -v selenium  # autodiscover and run the tests
 


### PR DESCRIPTION
Travis tests started to fail as Chrome doesn't support Ubuntu 12.04 anymore.

Use 14;04 machines for the Travis tests.

Install Chrome using Travis APT addon.

Read latest version of ChromeDriver from its release page.
We don't need to manually the bump the version again.

Remove redundant check about the machine architecture.
Travis machines are always 64 bit.

Do not install xvfb (already installed on Travis machines)

Run py.test with -v (verbose) switch.