### PR TITLE
Add origin removal capability to options page

### DIFF
--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -99,6 +99,9 @@
         "description": "This is the label for the 'Remove selected' buttons.",
         "message": "Remove selected"
     },
+    "remove_origin_confirmation": {
+        "message": "Are you sure you want to remove this origin from Privacy Badger?"
+    },
     "report_broken_site": {
         "message": "Report Broken Site"
     },

--- a/lib/options.js
+++ b/lib/options.js
@@ -153,12 +153,24 @@ function refreshOriginCache() {
 
 /**
  * Gets array of encountered origins.
+ * @param filterText {String} Text to filter origins against.
  * @return {Array}
  */
-function getOriginsArray() {
+function getOriginsArray(filterText) {
+  // Make sure filterText is lower case for case-insensitive matching.
+  if (filterText) {
+    filterText = filterText.toLowerCase();
+  } else {
+    filterText = '';
+  }
+
   var originsArray = [];
   for (var origin in originCache) {
-    originsArray.push(origin);
+
+    // Ignore origins that do not contain filter text.
+    if (origin.toLowerCase().indexOf(filterText) !== -1) {
+      originsArray.push(origin);
+    }
   }
   return originsArray;
 }
@@ -384,7 +396,15 @@ function refreshFilterPage() {
   $("#count").text(allTrackingDomains.length);
 
   // Display tracking domains.
-  showTrackingDomains(allTrackingDomains);
+  var originsToDisplay;
+  var searchText = $('#trackingDomainSearch').val();
+  if (searchText.length > 0) {
+    originsToDisplay = getOriginsArray(searchText);
+  } else {
+    originsToDisplay = allTrackingDomains;
+  }
+  showTrackingDomains(originsToDisplay);
+
   console.log("Done refreshing options page");
 }
 
@@ -405,18 +425,8 @@ function filterTrackingDomains(event) {
       return;
     }
 
-    // Filter tracking domains based on search text.
-    var allTrackingDomains = getOriginsArray();
-    var filteredTrackingDomains = [];
-    for (var i = 0; i < allTrackingDomains.length; i++) {
-      var trackingDomain = allTrackingDomains[i];
-
-      // Ignore domains that do not contain search text.
-      if (trackingDomain.toLowerCase().indexOf(searchText) !== -1) {
-        filteredTrackingDomains.push(trackingDomain);
-      }
-    }
-
+    // Get filtered tracking domains.
+    var filteredTrackingDomains = getOriginsArray(searchText);
     showTrackingDomains(filteredTrackingDomains);
   }, timeToWait);
 }

--- a/lib/options.js
+++ b/lib/options.js
@@ -17,8 +17,10 @@
 
 var backgroundPage = chrome.extension.getBackgroundPage();
 var require = backgroundPage.require;
-var seenThirdParties = backgroundPage.seenThirdParties;
-var imports = ["require", "saveAction", "removeFilter", "updateBadge"]
+var imports = [
+  "require", "saveAction", "removeFilter",
+  "removeOriginFromPrivacyBadger", "updateBadge"
+];
 for (var i = 0; i < imports.length; i++){
       window[imports[i]] = backgroundPage[imports[i]];
 }
@@ -68,6 +70,7 @@ function loadOptions() {
     $('#blockedResourcesContainer').on('mouseenter', '.tooltip', displayTooltip);
     $('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);
     $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
+    $('#blockedResourcesContainer').on('click', '.removeOrigin', removeOrigin);
   });
 
   // Display jQuery UI elements
@@ -235,7 +238,7 @@ function getOrigins()
   }
 
   // Process origins that have been seen but not blocked yet.
-  var seen = Object.keys(seenThirdParties);
+  var seen = Object.keys(backgroundPage.seenThirdParties);
   for (var i = 0; i < seen.length; i++) {
     var origin = seen[i];
     if (! origins[origin]) {
@@ -281,6 +284,26 @@ function revertDomainControl(e){
   selector.click();
   $elm.removeClass('userset');
   return false;
+}
+
+/**
+ * Removes origin from Privacy Badger.
+ *
+ * @param event {Event} Click event triggered by user.
+ */
+function removeOrigin(event) {
+  // Confirm removal before proceeding.
+  var removalConfirmed = confirm(i18n.getMessage("remove_origin_confirmation"));
+  if (! removalConfirmed) {
+    return;
+  }
+
+  // Remove origin from Privacy Badger.
+  var $element = $(event.target).parent();
+  var origin = $element.data('origin');
+  removeOriginFromPrivacyBadger(origin);
+
+  refreshFilterPage();
 }
 
 function toggleEnabled() {

--- a/skin/popup.css
+++ b/skin/popup.css
@@ -83,6 +83,18 @@ a:hover { color: #ec9329 }
   float: left;
   display: inline;
 }
+
+.removeOrigin {
+  cursor: pointer;
+  float: right;
+  margin-right: 0px;
+  width: 10px;
+}
+
+.removeOrigin:hover {
+  color: red;
+}
+
 .switch-container{
   width: 115px;
   display: block;
@@ -112,11 +124,12 @@ a:hover { color: #ec9329 }
 .noaction .switch-candy a{
   background-color: #339900;
 }
-.honeybadgerPowered{
+.honeybadgerPowered {
+  margin-right: 10px;
   width: 20px;
   height: 20px;
   position: relative;
-  left: 345px;
+  left: 337px;
   bottom: 15px;
   cursor: pointer;
 }

--- a/src/background.js
+++ b/src/background.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of Privacy Badger <https://www.eff.org/privacybadger>
  * Copyright (C) 2014 Electronic Frontier Foundation
- * Derived from Adblock Plus 
+ * Derived from Adblock Plus
  * Copyright (C) 2006-2013 Eyeo GmbH
  *
  * Privacy Badger is free software: you can redistribute it and/or modify
@@ -42,7 +42,7 @@ if (!("showCounter" in localStorage)){
   localStorage.showCounter = "true";
 }
 
-// Add a permanent store for seen third parties 
+// Add a permanent store for seen third parties
 var seenCache = localStorage.getItem("seenThirdParties");
 var seenThirdParties = JSON.parse(seenCache);
 if (!seenThirdParties){
@@ -238,6 +238,34 @@ function removeFilter(subscriptionName, filterName){
 }
 
 /**
+ * Removes traces of given origin from Privacy Badger.
+ *
+ * @param origin {String} Origin to remove.
+ */
+function removeOriginFromPrivacyBadger(origin) {
+  // Remove origin from ABP filters. This includes origins blocked by
+  // Privacy Badger heuristic as well as those overridden by user.
+  var filterName = '||' + origin + '^$third-party';
+  var subscriptionNames = [
+    'frequencyHeuristic',
+    'userRed',
+    'userYellow',
+    'userGreen',
+  ];
+  for (var i = 0; i < subscriptionNames.length; i++) {
+    var subscriptionName = subscriptionNames[i];
+    removeFilter(subscriptionName, filterName);
+  }
+
+  // Remove origin from origins that have been seen by Privacy Badger.
+  delete seenThirdParties[origin];
+  for (var seenOrigin in seenThirdParties) {
+    delete seenThirdParties[seenOrigin][origin];
+  }
+  localStorage.setItem('seenThirdParties', JSON.stringify(seenThirdParties));
+}
+
+/**
  * Checks whether a page is whitelisted.
  * @param {String} url
  * @param {String} parentUrl URL of the parent frame
@@ -340,8 +368,8 @@ function addSubscription(prevVersion) {
     localStorage.setItem("supercookieDomains", JSON.stringify({}));
   }
 
-  // Add a permanent store for blocked domains to recheck DNT compliance 
-  // TODO: storing this in localStorage makes it synchronous, but we might 
+  // Add a permanent store for blocked domains to recheck DNT compliance
+  // TODO: storing this in localStorage makes it synchronous, but we might
   // want the speed up of async later if we want to deal with promises
   var blockedDomains = JSON.parse(localStorage.getItem("blockeddomainslist"));
   if (!blockedDomains){
@@ -746,7 +774,7 @@ function saveAction(userAction, origin, target) {
     FilterStorage.addFilter(filter, FilterStorage.knownSubscriptions[allUserActions[userAction]]);
     console.log("Finished saving action " + userAction + " for " + origin + "on" + target);
     return true;
-  } 
+  }
 
   // If there is no target proceed as normal
   for (var action in allUserActions) {
@@ -836,7 +864,7 @@ function setTrackingFlag(tabId,fqdn){
 }
 
 function originHasTracking(tabId,fqdn){
-  return tabData[tabId] && 
+  return tabData[tabId] &&
     tabData[tabId].trackers &&
     !!tabData[tabId].trackers[fqdn];
 }
@@ -912,7 +940,7 @@ chrome.webRequest.onBeforeRequest.addListener(updateCount, {urls: ["http://*/*",
 
 
 /**
-* Populate tabs object with currently open tabs when extension is updated or installed. 
+* Populate tabs object with currently open tabs when extension is updated or installed.
 */
 function updateTabList(){
   console.log('update tabs!');
@@ -942,7 +970,7 @@ function updateTabList(){
 /**
  * Decide what the action would presumably be for an origin
  * used to determine where the slider should go when the undo button
- * is clicked. 
+ * is clicked.
  *
  * @param string origin the domain to guess the action for
  */

--- a/src/htmlutils.js
+++ b/src/htmlutils.js
@@ -130,6 +130,7 @@ var htmlUtils = exports.htmlUtils = {
     var originHtml = '' +
       '<div ' + classText + ' data-origin="' + origin + '" tooltip="' + actionDescription + '" data-original-action="' + action + '">' +
       '<div class="origin">' + whitelistedText + htmlUtils.trim(origin + subdomainText, 30) + '</div>' +
+      '<div class="removeOrigin">&#10006</div>' +
       htmlUtils.getToggleHtml(origin, action) +
       '<div class="honeybadgerPowered tooltip" tooltip="'+ tooltipText + '"></div>' +
       '<img class="tooltipArrow" src="/icons/badger-tb-arrow.png">' +

--- a/src/popup.js
+++ b/src/popup.js
@@ -36,7 +36,13 @@
 
 var backgroundPage = chrome.extension.getBackgroundPage();
 var require = backgroundPage.require;
-var imports = ["require", "isWhitelisted", "extractHostFromURL", "refreshIconAndContextMenu", "getAction", "blockedOriginCount", "activelyBlockedOriginCount", "userConfiguredOriginCount", "getAllOriginsForTab", "console", "whitelistUrl", "removeFilter", "setupCookieBlocking", "teardownCookieBlocking", "reloadTab", "saveAction", "getHostForTab", "getBaseDomain", "getPresumedAction"];
+var imports = [
+  "require", "isWhitelisted", "extractHostFromURL", "refreshIconAndContextMenu",
+  "getAction", "blockedOriginCount", "activelyBlockedOriginCount", "reloadTab",
+  "userConfiguredOriginCount", "getAllOriginsForTab", "console", "whitelistUrl",
+  "removeFilter", "setupCookieBlocking", "saveAction", "teardownCookieBlocking",
+  "getHostForTab", "getBaseDomain", "getPresumedAction",
+];
 var i18n = chrome.i18n;
 for (var i = 0; i < imports.length; i++){
   window[imports[i]] = backgroundPage[imports[i]];
@@ -76,7 +82,7 @@ function init() {
   var nag = $("#instruction");
   var outer = $("#instruction-outer");
 
-  var seenComic = JSON.parse(localStorage.getItem("seenComic")) || false; 
+  var seenComic = JSON.parse(localStorage.getItem("seenComic")) || false;
   console.log(seenComic);
 
   function _setSeenComic() {
@@ -90,7 +96,7 @@ function init() {
   }
 
   if (!seenComic) {
-    nag.show(); 
+    nag.show();
     outer.show();
     // Attach event listeners
     $('#fittslaw').click(_hideNag);
@@ -100,7 +106,7 @@ function init() {
       });
       _hideNag();
     });
-  } 
+  }
 
   $("#activate_site_btn").click(active_site);
   $("#deactivate_site_btn").click(deactive_site);
@@ -457,6 +463,12 @@ function refreshPopup(tabId) {
     });
   });
   adjustNoInitialBlockingLink();
+
+  // Hide elements for removing origins (controlled from the options page).
+  // Popup shows what's loaded for the current page so it doesn't make sense
+  // to have removal ability here.
+  $('.removeOrigin').hide();
+
   console.log("Done refreshing popup");
 }
 


### PR DESCRIPTION
This fixes #589 by adding elements for removing origins on the *User Filter Settings* tab of the options page. Origins are removed from the ABP filters (heuristic and user overrides) as well as from list of seen origins. I believe this covers everything but let me know if I'm missing something.

Also, let me know if you'd prefer these changes to be implemented after the switch to the new storage engine.