### PR TITLE
Fix options page refresh while origins filtered

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Adblock Plus.  If not, see <http://www.gnu.org/licenses/>.
  */
- // TODO: This code is a hideous mess and desperately needs to be refactored and cleaned up. 
+ // TODO: This code is a hideous mess and desperately needs to be refactored and cleaned up.
 
 var backgroundPage = chrome.extension.getBackgroundPage();
 var require = backgroundPage.require;
@@ -118,10 +118,22 @@ function refreshOriginCache() {
 
 /**
  * Gets array of encountered origins.
+ * @param filterText {String} Text to filter origins with.
  * @return {Array}
  */
-function getOriginsArray() {
-  return Object.keys(originCache);
+function getOriginsArray(filterText) {
+  // Make sure filterText is lower case for case-insensitive matching.
+  if (filterText) {
+    filterText = filterText.toLowerCase();
+  } else {
+    filterText = "";
+  }
+
+  // Include only origins containing given filter text.
+  function containsFilterText(origin) {
+    return origin.toLowerCase().indexOf(filterText) !== -1;
+  }
+  return Object.keys(originCache).filter(containsFilterText);
 }
 
 function addWhitelistDomain(event) {
@@ -223,7 +235,15 @@ function refreshFilterPage() {
   $("#count").text(allTrackingDomains.length);
 
   // Display tracking domains.
-  showTrackingDomains(allTrackingDomains);
+  var originsToDisplay;
+  var searchText = $("#trackingDomainSearch").val();
+  if (searchText.length > 0) {
+    originsToDisplay = getOriginsArray(searchText);
+  } else {
+    originsToDisplay = allTrackingDomains;
+  }
+  showTrackingDomains(originsToDisplay);
+
   console.log("Done refreshing options page");
 }
 
@@ -244,19 +264,9 @@ function filterTrackingDomains(/*event*/) {
       return;
     }
 
-    // Filter tracking domains based on search text.
-    var allTrackingDomains = getOriginsArray();
-    var filteredTrackingDomains = [];
-    for (var i = 0; i < allTrackingDomains.length; i++) {
-      var trackingDomain = allTrackingDomains[i];
-
-      // Ignore domains that do not contain search text.
-      if (trackingDomain.toLowerCase().indexOf(searchText) !== -1) {
-        filteredTrackingDomains.push(trackingDomain);
-      }
-    }
-
-    showTrackingDomains(filteredTrackingDomains);
+    // Show filtered origins.
+    var filteredOrigins = getOriginsArray(searchText);
+    showTrackingDomains(filteredOrigins);
   }, timeToWait);
 }
 


### PR DESCRIPTION
This fixes item 6 mentioned in my comment in #819, namely the refresh of the options page causing an existing filter to be reset for the list of origins. Now an action like filtering the list of origins and setting a user override for an origin won't cause all origins to be displayed after the refresh.