### PR TITLE
Add origin removal capability

### DIFF
--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -53,6 +53,9 @@
     "options_loading": {
         "message": "Loading..."
     },
+    "options_remove_origin_confirm": {
+        "message": "Are you sure you want to remove this origin from Privacy Badger?"
+    },
     "options_slider_text": {
         "message": "Privacy Badger is protecting you across the web! These sliders let you control how Privacy Badger handles each tracker that it has flagged through your browsing."
     },

--- a/skin/popup.css
+++ b/skin/popup.css
@@ -83,6 +83,18 @@ a:hover { color: #ec9329 }
   float: left;
   display: inline;
 }
+
+.removeOrigin {
+  cursor: pointer;
+  float: right;
+  margin-right: 0px;
+  width: 10px;
+}
+
+.removeOrigin:hover {
+  color: red;
+}
+
 .switch-container{
   width: 115px;
   display: block;
@@ -114,10 +126,11 @@ a:hover { color: #ec9329 }
   background-color: #339900;
 }
 .honeybadgerPowered{
+  margin-right: 10px;
   width: 20px;
   height: 20px;
   position: relative;
-  left: 345px;
+  left: 337px;
   bottom: 15px;
   cursor: pointer;
 }

--- a/src/htmlutils.js
+++ b/src/htmlutils.js
@@ -132,6 +132,7 @@ var htmlUtils = exports.htmlUtils = {
     var originHtml = '' +
       '<div ' + classText + ' data-origin="' + origin + '" tooltip="' + actionDescription + '" data-original-action="' + action + '">' +
       '<div class="origin">' + whitelistedText + htmlUtils.trim(origin + subdomainText, 30) + '</div>' +
+      '<div class="removeOrigin">&#10006</div>' +
       htmlUtils.getToggleHtml(origin, action) +
       '<div class="honeybadgerPowered tooltip" tooltip="'+ tooltipText + '"></div>' +
       '<img class="tooltipArrow" src="/icons/badger-tb-arrow.png">' +

--- a/src/options.js
+++ b/src/options.js
@@ -216,9 +216,13 @@ function refreshFilterPage() {
   // Check to see if any tracking domains have been found before continuing.
   var allTrackingDomains = getOriginsArray();
   if (!allTrackingDomains || allTrackingDomains.length === 0) {
+    $("#count").text(0);
     $("#blockedResources").html("Could not detect any tracking cookies.");
     return;
   }
+
+  // Update tracking domain count.
+  $("#count").text(allTrackingDomains.length);
 
   // Display tracker tooltips.
   var trackerTooltips = '<div id="associatedTab" data-tab-id="000"></div>' +
@@ -232,9 +236,6 @@ function refreshFilterPage() {
     '<div class="spacer"></div>' +
     '<div id="blockedResourcesInner" class="clickerContainer"></div>';
   $("#blockedResources").html(trackerTooltips);
-
-  // Update tracking domain count.
-  $("#count").text(allTrackingDomains.length);
 
   // Display tracking domains.
   var originsToDisplay;

--- a/src/options.js
+++ b/src/options.js
@@ -42,12 +42,13 @@ function loadOptions() {
   $("#trackingDomainSearch").attr("placeholder", i18n.getMessage("options_domain_search"));
   $("#trackingDomainSearch").on("input", filterTrackingDomains);
 
-  // load resources for filter sliders
+  // Add event listeners for origins container.
   $(function () {
     $('#blockedResourcesContainer').on('change', 'input:radio', updateOrigin);
     $('#blockedResourcesContainer').on('mouseenter', '.tooltip', displayTooltip);
     $('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);
     $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
+    $('#blockedResourcesContainer').on('click', '.removeOrigin', removeOrigin);
   });
 
   // Display jQuery UI elements
@@ -339,6 +340,28 @@ function updateOrigin(event){
   var origin = $clicker.data('origin');
   $clicker.attr('tooltip', htmlUtils.getActionDescription(action, origin));
   $clicker.children('.tooltipContainer').html(htmlUtils.getActionDescription(action, origin));
+}
+
+/**
+ * Remove origin from Privacy Badger.
+ * @param event {Event} Click event triggered by user.
+ */
+function removeOrigin(event) {
+  // Confirm removal before proceeding.
+  var removalConfirmed = confirm(i18n.getMessage("options_remove_origin_confirm"));
+  if (!removalConfirmed) {
+    return;
+  }
+
+  // Remove traces of origin from storage.
+  var $element = $(event.target).parent();
+  var origin = $element.data('origin');
+  pb.storage.getBadgerStorageObject("snitch_map").deleteItem(origin);
+  pb.storage.getBadgerStorageObject("action_map").deleteItem(origin);
+  pb.storage.getBadgerStorageObject("supercookie_domains").deleteItem(origin);
+  pb.log('Removed', origin, 'from Privacy Badger');
+
+  refreshFilterPage();
 }
 
 var tooltipDelay = 300;

--- a/src/popup.js
+++ b/src/popup.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
- // TODO: This code is a hideous mess and desperately needs to be refactored and cleaned up. 
+ // TODO: This code is a hideous mess and desperately needs to be refactored and cleaned up.
 
 var backgroundPage = chrome.extension.getBackgroundPage();
 var require = backgroundPage.require;
@@ -34,7 +34,7 @@ function init() {
   var nag = $("#instruction");
   var outer = $("#instruction-outer");
 
-  var seenComic = settings.getItem("seenComic") || false; 
+  var seenComic = settings.getItem("seenComic") || false;
 
   function _setSeenComic() {
     settings.setItem("seenComic", "true");
@@ -47,7 +47,7 @@ function init() {
   }
 
   if (!seenComic) {
-    nag.show(); 
+    nag.show();
     outer.show();
     // Attach event listeners
     $('#fittslaw').click(_hideNag);
@@ -57,7 +57,7 @@ function init() {
       });
       _hideNag();
     });
-  } 
+  }
 
   $("#activate_site_btn").click(active_site);
   $("#deactivate_site_btn").click(deactive_site);
@@ -281,7 +281,7 @@ function refreshPopup(tabId) {
       if (action.includes("user")){
         var prevOrigin = origin;
         var baseDomain = backgroundPage.getBaseDomain(prevOrigin);
-        // TODO make some re-implementation of getBestAction that returns where the 
+        // TODO make some re-implementation of getBestAction that returns where the
         // user rule is coming from
         if (getTopLevel(action, origin, tabId) == baseDomain && baseDomain != origin){
           origin = baseDomain;
@@ -341,6 +341,12 @@ function refreshPopup(tabId) {
     });
   });
   adjustNoInitialBlockingLink();
+
+  // Hide elements for removing origins (controlled from the options page).
+  // Popup shows what's loaded for the current page so it doesn't make sense
+  // to have removal ability here.
+  $('.removeOrigin').hide();
+
   console.log("Done refreshing popup");
 }
 

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -101,8 +101,10 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
 
         # Reload options page and make sure origin is displayed.
         self.load_url(pbtest.PB_CHROME_OPTIONS_PAGE_URL)
+        origins = self.driver.find_element_by_id("blockedResourcesInner")
+        self.assertEqual(self.driver.find_element_by_id("count").text, "1",
+                         "Origin count should be 1 after adding origin")
         try:
-            origins = self.driver.find_element_by_id("blockedResourcesInner")
             origins.find_element_by_xpath(
                 origin_xpath + origin_display_xpath)
             remove_origin_element = origins.find_element_by_xpath(
@@ -119,8 +121,13 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
                 origin_xpath + origin_display_xpath)
         except NoSuchElementException:
             origin_element = None
-        self.assertIsNone(
-            origin_element, "Origin should not be displayed after removal")
+        self.assertIsNone(origin_element,
+                          "Origin should not be displayed after removal")
+        try:
+            WebDriverWait(self.driver, 5).until(
+                EC.text_to_be_present_in_element((By.ID, "count"), "0"))
+        except TimeoutException:
+            self.fail("Origin count should be 0 after deleting origin")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes #589 by adding the capability of removing origins from Privacy Badger on the options page. It's set up to remove the selected origin from the *action_map*, *snitch_map*, and *supercookie_domains* storage objects. I think this should cover everything but let me know if I'm missing anything or if any of my assumptions are wrong.