### PR TITLE
Use tab method supported by Firefox and Chrome

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -391,7 +391,7 @@ function syncSettings(origin, userAction) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
-  chrome.tabs.getSelected(null, function(/*tab*/) {
+  chrome.tabs.query({currentWindow: true}, function(/*tab*/) {
     refreshFilterPage();
   });
 });


### PR DESCRIPTION
This line was throwing an error because the *getSelected* method is unsupported in Firefox. Maybe this section of code should just be removed though? Maybe it serves some purpose but it looks like it just refreshes the tracker list again after the options page finishes loading which seems unnecessary.