### PR TITLE
Remove missing localized string on options page (firefox-compat branch)

### DIFF
--- a/skin/options.html
+++ b/skin/options.html
@@ -217,7 +217,6 @@ a, a:hover, a:active, a:visited{
   </div>
 
   <div id="tab-general-settings">
-    <p class="i18n_general_settings_help"></p>
     <form id="settingsForm" action="#">
       <div class="checkbox">
         <label><input type="checkbox" id="toggle_counter_checkbox"><span class="i18n_show_counter_checkbox"></span></label>


### PR DESCRIPTION
This string isn't defined in any of the localization files. Chrome doesn't render missing localized text while Firefox renders it as "???".

Only tangentially related, would it be worth consolidating the *Social Widget Settings* and *General Settings* tabs, similar to the current Firefox version? i.e. have the social widget setting listed as a checkbox under general settings.