### PR TITLE
Remove duplicate refresh while opening options (firefox-compat branch)

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -389,9 +389,3 @@ function syncSettings(origin, userAction) {
   // Options page needs to be refreshed to display current results.
   refreshFilterPage();
 }
-
-document.addEventListener('DOMContentLoaded', function() {
-  chrome.tabs.query({currentWindow: true}, function(/*tab*/) {
-    refreshFilterPage();
-  });
-});


### PR DESCRIPTION
Original discussion in #849.

This code does indeed cause an extra unnecessary refresh of the tracker list when opening the options page. What ends up happening is the tracker list refreshes twice in quick succession and the domains being displayed during both refreshes are exactly the same.

Removing this makes opening the options page a little snappier as well.