### PR TITLE
Fix several errors.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -67,8 +67,6 @@ function Badger(tabData, isIncognito) {
     // TODO: register all privacy badger listeners here in the storage callback
 
     badger.INITIALIZED = true;
-    console.log('privacy badger is ready to rock');
-    console.log('set DEBUG=1 to view console messages');
   });
 }
 
@@ -733,6 +731,8 @@ function startBackgroundListeners() {
 /**
  * lets get this party started
  */
+console.log('Loading badgers into the pen.');
+
 var pb = new Badger({}, false);
 var incognito_pb = new Badger({}, true);
 
@@ -743,3 +743,6 @@ incognito.startListeners();
 webrequest.startListeners();
 HeuristicBlocking.startListeners();
 startBackgroundListeners();
+
+console.log('Privacy badger is ready to rock!');
+console.log('Set DEBUG=1 to view console messages.');

--- a/src/background.js
+++ b/src/background.js
@@ -348,7 +348,7 @@ Badger.prototype = {
     ];
 
     for (var i = migrationLevel; i < migrations.length; i++) {
-      migrations[i].call(Migrations);
+      migrations[i].call(Migrations, this.storage);
       settings.setItem('migrationLevel', i+1);
     }
 

--- a/src/background.js
+++ b/src/background.js
@@ -455,10 +455,6 @@ Badger.prototype = {
    * @param {Object} details details object from onBeforeRequest event
    */
   updateCount: function(details) {
-    if (details.tabId == -1){
-      return {};
-    }
-
     if(!this.isPrivacyBadgerEnabled(webrequest.getHostForTab(details.tabId))){
       return;
     }
@@ -684,8 +680,10 @@ function getBadgerWithTab(tabId) {
 
 function startBackgroundListeners() {
   chrome.webRequest.onBeforeRequest.addListener(function(details) {
-    var badger = getBadgerWithTab(details.tabId);
-    badger.updateCount(details);
+    if (details.tabId != -1){
+      var badger = getBadgerWithTab(details.tabId);
+      badger.updateCount(details);
+    }
   }, {urls: ["http://*/*", "https://*/*"]}, []);
 
 

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -15,7 +15,6 @@
  * along with Privacy Badger.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var pbStorage = require("storage");
 var utils = require("utils");
 var constants = require("constants");
 
@@ -145,15 +144,15 @@ exports.Migrations= {
     */
   },
 
-  migrateBlockedSubdomainsToCookieblock(){
+  migrateBlockedSubdomainsToCookieblock(storage){
     setTimeout(function(){
       console.log('MIGRATING BLOCKED SUBDOMAINS THAT ARE ON COOKIE BLOCK LIST');
-      var cbl = pbStorage.getBadgerStorageObject('cookieblock_list');
-      _.each(pbStorage.getAllDomainsByPresumedAction(constants.BLOCK), function(fqdn){
+      var cbl = storage.getBadgerStorageObject('cookieblock_list');
+      _.each(storage.getAllDomainsByPresumedAction(constants.BLOCK), function(fqdn){
         _.each(utils.explodeSubdomains(fqdn, true), function(domain){
           if(cbl.hasItem(domain)){
             console.log('moving', fqdn, 'from block to cookie block');
-            pbStorage.setupHeuristicAction(fqdn, constants.COOKIEBLOCK);
+            storage.setupHeuristicAction(fqdn, constants.COOKIEBLOCK);
           }
         });
       });

--- a/src/storage.js
+++ b/src/storage.js
@@ -53,7 +53,6 @@ require.scopes.storage = (function() {
  **/
 
 function BadgerPen(isIncognito, callback) {
-  console.log('loading badgers into the pen');
   var keys = [
     "snitch_map",
     "action_map",


### PR DESCRIPTION
The commits explain them pretty well.

* Fix errors with `updateCount` for no tab requests. Internal xhrs were causing us to update pb's badge. But these don't have an associated tab, which was causing the error.

* Remove duplicate startup messages. The 'pb is ready to rock' message is kind of a lie now since the initialization funcs are asynchronous. But it is close enough.

* Fix error in migrations. This is bug was due to my refactoring. The `storage.getBadgerStorageObject` is a method on a badger instance now instead of a function. But that wasn't changed in this migrations code.