### PR TITLE
Tidying up scrollbar in popup

### DIFF
--- a/skin/popup.css
+++ b/skin/popup.css
@@ -220,8 +220,8 @@ font-size: 16px;
 #noBlockingLink a {
   color:#4183c4;
 }
-#blockedResources{
-  max-height: 320px;
+.clickerContainer {
+  max-height: 290px;
   overflow-y: auto;
   background-color: #E8E9EA;
 }


### PR DESCRIPTION
Turns out the scrollbar *is* showing by default (re #591); not sure what I was looking at before. However, it was getting cut off. I made a minor tweak to the CSS to set the properties for the `clickerContainer` class rather than the `blockedResources` id. `blockedResources` contains `clickerContainer` but also contains the blocked, cookieblocked and allowed icons at the top. Because of this, the scrollbar was starting from the top of the box, whereas it should have started from beneath those icons.

Here are before and after screenshots:
![scroll before](https://cloud.githubusercontent.com/assets/11308076/18505563/adba0410-7a1c-11e6-950f-f41e02320d2e.png)
![scroll after](https://cloud.githubusercontent.com/assets/11308076/18505564/adf4c9d8-7a1c-11e6-8463-19247b0a75cb.png)