### PR TITLE
Improve Travis tests (#924).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ addons:
     - google-chrome
     packages:
     - google-chrome-stable
+    - python-virtualenv
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-install:
-  - sudo apt-get update
-  - sudo apt-get -qq install python-virtualenv
 before_script:
   - ./scripts/setup_travis.sh
   - cd tests
-script:  ./run_selenium_tests.sh
+script:  travis_retry ./run_selenium_tests.sh

--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 # Install chromedriver
 
-if [ -x /usr/local/bin/chromedriver ]; then
-    echo "You already have ChromeDriver installed. Skipping this step."
-else
-    latest_version=$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)
-    wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${latest_version}/chromedriver_linux64.zip"
-    sudo unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
-    sudo chmod a+x /usr/local/bin/chromedriver
-fi
+latest_version=$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)
+wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${latest_version}/chromedriver_linux64.zip"
+sudo unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
+sudo chmod a+x /usr/local/bin/chromedriver

--- a/tests/run_selenium_tests.sh
+++ b/tests/run_selenium_tests.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
-if [ -x /usr/local/bin/chromedriver ]; then
-	echo "Will use ChromeDriver at /usr/local/bin/chromedriver"
-elif [ -x /usr/lib/chromium-browser/chromedriver ]; then
-        export PATH=$PATH:/usr/lib/chromium-browser
-        echo "Will use ChromeDriver at /usr/lib/chromium-browser/chromedriver"
-elif [ -x /usr/lib/chromium/chromedriver ]; then
-        export PATH=$PATH:/usr/lib/chromium
-        echo "Will use ChromeDriver at /usr/lib/chromium/chromedriver"
-else
-	echo "Could not find ChromeDriver in the PATH. Aborting!"
-	exit 1
-fi
+command -v chromedriver >/dev/null 2>&1 || { echo >&2 "Cannot find chromedriver in PATH. Aborting."; exit 1; }
 
 pushd .
 cd ..
@@ -30,5 +19,5 @@ export BROWSER_BIN=""   # Path to the browser binary. Optional.
 # If empty, Selenium will pick the default binary for the selected browser.
 # To run tests with Chromium (instead of default Google Chrome) export BROWSER_BIN="/usr/bin/chromium-browser"
 export ENABLE_XVFB=1    # run the tests headless using Xvfb. Set 0 to disable
-py.test -s -v selenium  # autodiscover and run the tests
-
+# for i in {1..20}; do echo "Run "$i; py.test -s -v --durations=10 selenium; done  # autodiscover and run the tests
+py.test -s -v --durations=10 selenium  # autodiscover and run the tests

--- a/tests/selenium/breakage_test.py
+++ b/tests/selenium/breakage_test.py
@@ -8,15 +8,16 @@ from selenium.webdriver.support import expected_conditions as EC
 
 
 class Test(pbtest.PBSeleniumTest):
-    """Make sure we don't badly break things when we install the extension.
+    """Make sure the extension doesn't break common sites and use cases.
     e.g. we should be able to load a website, search on Google.
-    TODO: Add other tests to simulate most common web use cases:
+    TODO: Add tests to simulate most common web use cases:
     e.g. play Youtube videos, login to popular services, tweet some text,
     add Reddit comments etc."""
 
     def test_should_load_eff_org(self):
         self.load_url("https://www.eff.org")
-        WebDriverWait(self.driver, 10).until(EC.title_contains("Electronic Frontier Foundation"))
+        WebDriverWait(self.driver, 10).\
+            until(EC.title_contains("Electronic Frontier Foundation"))
 
     def test_should_search_google(self):
         self.load_url("https://www.google.com/")

--- a/tests/selenium/cookie_test.py
+++ b/tests/selenium/cookie_test.py
@@ -34,7 +34,7 @@ class CookieTest(pbtest.PBSeleniumTest):
              "Cookie test failed: %s" % test_name)
 
     def test_should_pass_std_cookie_test(self):
-        self.assert_pass_opera_cookie_test("http://jsbin.com/soluqi/1/",
+        self.assert_pass_opera_cookie_test("https://gistcdn.githack.com/gunesacar/79aa14bac95694d38425d458843dacd6/raw/3d17cc07e071a45c0bf536b907b6848786090c8a/cookie.html",  # noqa
                                            "Set 1st party cookie")
     # TODO: FIXME!
     def FIXMEtest_cookie_tracker_detection(self):

--- a/tests/selenium/localstorage_test.py
+++ b/tests/selenium/localstorage_test.py
@@ -3,7 +3,6 @@
 
 import unittest
 import pbtest
-import json
 from time import sleep
 
 # time to wait for loading privacy policy from eff.org
@@ -22,29 +21,36 @@ class LocalStorageTest(pbtest.PBSeleniumTest):
     """
     def check_policy_download(self):
         timeout = POLICY_DOWNLOAD_TIMEOUT
+        dnt_hashes_not_empty =\
+            "return (pb.storage.getBadgerStorageObject('dnt_hashes') != {})"
         # give updatePrivacyPolicyHashes() sometime to download the policy hash
-        while (timeout > 0 and 
-                not self.js("return (pb.storage.getBadgerStorageObject('dnt_hashes') != {})")):
+        while (timeout > 0 and not self.js(dnt_hashes_not_empty)):
             sleep(1)
             timeout -= 1
 
         # make sure we didn't time-out
         self.assertGreater(timeout, 0,
-            "Timed out while waiting for the localStorage.badgerHashes")
+                           "Timed out while waiting for the "
+                           "localStorage.badgerHashes")
         # now check the downloaded policy hash
-        policy_hash = self.js("return (pb.storage.getBadgerStorageObject('dnt_hashes').getItemClones())")
-        for k, v in policy_hash.items():
-            # self.assertIn("DNT Policy", k)  # e.g. DNT Policy V1.0
-            self.assertEqual(PB_POLICY_HASH_LEN, len(k))  # check hash length
+        get_dnt_hashes =\
+            "return (pb.storage.getBadgerStorageObject('dnt_hashes')."\
+            "getItemClones())"
+        print self.js("return pb.storage.getBadgerStorageObject('dnt_hashes')")
+        policy_hashes = self.js(get_dnt_hashes)
+        for policy_hash in policy_hashes.keys():
+            self.assertEqual(PB_POLICY_HASH_LEN, len(policy_hash))
 
     def test_should_init_local_storage_entries(self):
-        self.load_url(pbtest.PB_CHROME_BG_URL)
+        self.load_url(pbtest.PB_CHROME_BG_URL, wait_on_site=3)
         js = self.js
         self.check_policy_download()
         self.assertEqual(js("return constants.COOKIE_BLOCK_LIST_URL"),
                          "https://www.eff.org/files/cookieblocklist_new.txt")
 
-        disabled_sites = js("return (pb.storage.getBadgerStorageObject('settings_map').getItem('disabledSites'))");
+        get_disabled_sites = "return (pb.storage.getBadgerStorageObject("\
+            "'settings_map').getItem('disabledSites'))"
+        disabled_sites = js(get_disabled_sites)
 
         self.assertFalse(len(disabled_sites),
                          "Shouldn't have any disabledSites after installation")

--- a/tests/selenium/pbtest_org_test.py
+++ b/tests/selenium/pbtest_org_test.py
@@ -2,13 +2,10 @@
 # -*- coding: UTF-8 -*-
 
 import pbtest
-import sys
 import time
 import unittest
-
-#import IPython
-
-from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException, TimeoutException
+from selenium.common.exceptions import (NoSuchElementException,
+                                        StaleElementReferenceException)
 
 # where to run the acceptance tests
 PBTEST_ORG_URL = "https://pbtest.org/tracker"
@@ -16,17 +13,19 @@ PBTEST_ORG_URL = "https://pbtest.org/tracker"
 # the id of the element where test results are reported
 PBTEST_ORG_TEST_RESULTS_TABLE_ID = "results"
 
-# the unicode characters we look for the the results to tell if a test passed or failed
+# unicode characters we look in the results to tell if a test passed or failed
 PASS = u'\u2713'
 FAIL = u'\u2717'
 
+
 class PBTest_Org_test(pbtest.PBSeleniumTest):
-    """Run the pbtest.org website acceptance tests. Loads the pbtest.org test suite and assert that
-       none of the tests failed. Ignores tests with a status of "undefined" and any tests not
-       visible to the user. """
+    """Run the pbtest.org website acceptance tests. Loads the pbtest.org test
+       suite and assert that none of the tests failed. Ignores tests with a
+       status of "undefined" and any tests not visible to the user."""
 
     def test_should_pass_pbtest_org_suite(self):
-        self.driver.delete_all_cookies()
+        driver = self.driver
+        driver.delete_all_cookies()
         # possible fixme: check for chrome settings for third party cookies?
 
         # there's some chromedriver / welcome page weirdness where chromedriver
@@ -34,76 +33,87 @@ class PBTest_Org_test(pbtest.PBSeleniumTest):
         # immediately opens its first time welcome page in another tab.
         # the workaround is to load the pb page; let pb open the first time
         # page; switch to the first time page and close it; then go back
-        # to the pb test page and reload the page again. 
-        self.driver.get( PBTEST_ORG_URL )
-        print("loaded window at %s" % ( PBTEST_ORG_URL))
+        # to the pb test page and reload the page again.
+        driver.get(PBTEST_ORG_URL)
+        print("loaded window at %s" % (PBTEST_ORG_URL))
         time.sleep(5)
-        for w in self.driver.window_handles:
-            self.driver.switch_to.window( w )
-            if self.driver.current_url.startswith(u'chrome-extension://'):
-                print("going to close window " + self.driver.current_url)
-                self.driver.close()
-        self.driver.switch_to.window( self.driver.window_handles[0] )
-        self.driver.get( PBTEST_ORG_URL )
+        for w in driver.window_handles:
+            driver.switch_to.window(w)
+            if driver.current_url.startswith(u'chrome-extension://'):
+                print("going to close window " + driver.current_url)
+                driver.close()
+        driver.switch_to.window(driver.window_handles[0])
+        driver.get(PBTEST_ORG_URL)
 
-        # get a list of all the data rows in the table, and sort them according to their
-        # current state: passed, failed, still_executing, or undefined. if they
-        # aren't all executed, wait a few seconds and try again. Max tries is 10.
-        tr_states = { 'passed':[], 'failed':[], 'still_executing':[], 'undefined': [] }
-        for i in range(10):
-            tr_states = { 'passed':[], 'failed':[], 'undefined': [], 'executing':[] }
+        # get a list of all the data rows in the table, and sort them according
+        # to their current state: passed, failed, still_executing, or
+        # undefined. if they aren't all executed, wait a few seconds and try
+        # again. Max tries is 10.
+        tr_states = {'passed': [], 'failed': [],
+                     'still_executing': [], 'undefined': []}
+        for _ in range(10):
+            tr_states = {'passed': [], 'failed': [],
+                         'undefined': [], 'executing': []}
             try:
-                results_table = self.driver.find_element_by_id( PBTEST_ORG_TEST_RESULTS_TABLE_ID )
+                results_table = driver.\
+                    find_element_by_id(PBTEST_ORG_TEST_RESULTS_TABLE_ID)
                 # pull out all the rows in the results table
                 all_trs = results_table.find_elements_by_tag_name("tr")
                 for tr in all_trs:
                     # skip the rows with th elements
                     headers = tr.find_elements_by_tag_name("th")
                     if headers:
-                            continue
+                        continue
                     # skip the rows that are not user-visible
                     if not tr.is_displayed():
-                            print(tr.text + ": this is not displayed - ignore")
-                            continue
+                        # print(tr.text + ": this is not displayed - ignore")
+                        continue
 
                     # pull out the test label and test status from the row
-                    (testname, teststatus) = tr.find_elements_by_tag_name("td")
+                    (_, teststatus) = tr.find_elements_by_tag_name("td")
 
                     # sort according to the test status
                     if PASS in teststatus.text:
-                            #print(tr.text + ": test has passed")
-                            tr_states['passed'].append( tr )
+                        # print(tr.text + ": test has passed")
+                        tr_states['passed'].append(tr)
                     elif FAIL in teststatus.text:
-                            tr_states['failed'].append( tr )
-                            #print(tr.text + ": test has failed")
+                        tr_states['failed'].append(tr)
+                        # print(tr.text + ": test has failed")
                     elif u'undefined' in teststatus.text:
-                            tr_states['undefined'].append( tr )
-                            #print(tr.text + ": test is undefined")
+                        tr_states['undefined'].append(tr)
+                        # print(tr.text + ": test is undefined")
                     else:
-                            #print(tr.text + ": test is executing")
-                            tr_states['executing'].append( tr )
+                        # print(tr.text + ": test is executing")
+                        tr_states['executing'].append(tr)
 
                 # some tests are not finished yet. sleep a bit and try again.
                 if tr_states['executing']:
-                        print("test not all completed yet. try again")
-                        time.sleep(5)
-                        continue
+                    print("Some tests did not finish yet. Will try again.")
+                    time.sleep(5)
+                    continue
 
-            # handle the case where the elements haven't been added to the DOM yet with a retry
-            except (NoSuchElementException, StaleElementReferenceException, ValueError):
+            # handle the case where the elements haven't been added to the
+            # DOM yet with a retry
+            except (NoSuchElementException, StaleElementReferenceException,
+                    ValueError):
                 time.sleep(5)
                 continue
 
             break
 
         # complain if all tests haven't completed by now
-        self.assertTrue( len(tr_states['executing']) == 0, msg="Problem test results execution on the server side.")
+        self.assertTrue(len(tr_states['executing']) == 0,
+                        msg="Some tests did not finish yet.")
 
-        # now we have all the completed test results. complain about any failed tests.
-        print("pbtest_org_test: %d tests passed, %d tests failed, %d tests undefined" % ( len(tr_states['passed']), len(tr_states['failed']), len(tr_states['undefined']) ))
+        # now we have all the completed test results.
+        # complain about any failed tests.
+        print("pbtest_org test results: %d passed, %d failed, %d undefined" %
+              (len(tr_states['passed']), len(tr_states['failed']),
+               len(tr_states['undefined'])))
         failed_tests = [t.text for t in tr_states['failed']]
-        fail_msg = "%d tests failed: %s" % ( len(failed_tests), ", ".join(failed_tests) )
-        self.assertTrue( len(failed_tests) == 0, msg=fail_msg  )
+        fail_msg = "%d tests failed: %s" % (len(failed_tests),
+                                            ", ".join(failed_tests))
+        self.assertTrue(len(failed_tests) == 0, msg=fail_msg)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/selenium/qunit_test.py
+++ b/tests/selenium/qunit_test.py
@@ -18,13 +18,15 @@ class Test(pbtest.PBSeleniumTest):
         self.load_url(pbtest.PB_CHROME_BG_URL)  # load a dummy page
         self.load_url(PB_CHROME_QUNIT_TEST_URL)
         try:
-            failed = self.txt_by_css("#qunit-testresult > span.failed", timeout=120)
+            failed = self.txt_by_css("#qunit-testresult > span.failed",
+                                     timeout=120)
         except TimeoutException as exc:
             self.fail("Cannot find the results of QUnit tests %s" % exc)
         passed = self.txt_by_css("#qunit-testresult > span.passed")
         total = self.txt_by_css("#qunit-testresult > span.total")
-        print("User agent:", self.txt_by_css("#qunit-userAgent"))
-        print("QUnits tests: Failed: %s Passed: %s Total: %s" % (failed, passed, total))
+        print("QUnits tests: Failed: %s Passed: %s Total: %s" % (failed,
+                                                                 passed,
+                                                                 total))
         self.assertEqual("0", failed)
         # TODO: Report failed QUnit tests
 

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -11,32 +11,42 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
 
     def has_supercookies(self, origin):
         """Check if the given origin has supercookies in PB's localStorage."""
-        self.load_url(pbtest.PB_CHROME_BG_URL)
-        get_sc_domains_js = "return JSON.stringify(pb.storage.getBadgerStorageObject('supercookie_domains').getItemClones())"
+        self.load_url(pbtest.PB_CHROME_BG_URL, wait_on_site=1)
+        get_sc_domains_js = "return JSON.stringify(pb.storage."\
+            "getBadgerStorageObject('supercookie_domains').getItemClones())"
         supercookieDomains = json.loads(self.js(get_sc_domains_js))
         return origin in supercookieDomains
 
-    # localStorage (ls) tests
     def test_should_detect_ls_of_third_party_frame(self):
-        self.load_url("https://jsfiddle.net/uon507ut/embedded/result/",
-                      wait_on_site=10)
-        self.assertTrue(self.has_supercookies("rawgit.com"))
+        """We get some intermittent failures for this test.
+
+        It seems we sometimes miss the setting of localStorage items,
+        perhaps because the script runs before we start intercepting the calls.
+
+        Perhaps related to: https://github.com/ghostwords/chameleon/issues/5
+        """
+        self.load_url("https://rawgit.com/gunesacar/24d81a5c964cb563614162c264be32f0/raw/8fa10f97b87343dfb62ae9b98b753c73a995157e/frame_ls.html",  # noqa
+                      wait_on_site=5)
+        self.driver.switch_to_frame(self.driver.
+                                    find_element_by_tag_name("iframe"))
+        print self.js("return localStorage['frameId']")
+        self.assertTrue(self.has_supercookies("githack.com"))
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):
-        self.load_url("https://jsfiddle.net/21za32ve/1/embedded/result/",
-                      wait_on_site=10)
-        self.assertFalse(self.has_supercookies("rawgit.com"))
+        self.load_url("https://rawgit.com/gunesacar/gunesacar/6f0c39fb728a218ccd91215bfefbd4e0/raw/f438eb4e5ce10dc8623a8834b1298fd4a846c6fa/low_entropy_localstorage_from_third_party_script.html",  # noqa
+                      wait_on_site=5)
+        self.assertFalse(self.has_supercookies("githack.com"))
 
     def test_should_not_detect_first_party_ls(self):
-        self.load_url("https://rawgit.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html",  # noqa
-                        wait_on_site=10)
-        self.assertFalse(self.has_supercookies("rawgit.com"))
+        self.load_url("https://gistcdn.githack.com/gunesacar/43e2ad2b76fa5a7f7c57/raw/44e7303338386514f1f5bb4166c8fd24a92e97fe/set_ls.html",  # noqa
+                      wait_on_site=5)
+        self.assertFalse(self.has_supercookies("githack.com"))
 
     def test_should_not_detect_ls_of_third_party_script(self):
         # a third-party script included by the top page (not a 3rd party frame)
-        self.load_url("https://jsfiddle.net/gzehyh92/embedded/result/",
-                      wait_on_site=10)
-        self.assertFalse(self.has_supercookies("rawgit.com"))
+        self.load_url("https://rawgit.com/gunesacar/b366e3b03231dbee9709fe0a614faf10/raw/48e02456aa257e272092b398772a712391cf8b11/localstorage_from_third_party_script.html",  # noqa
+                      wait_on_site=5)
+        self.assertFalse(self.has_supercookies("githack.com"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/selenium/window_utils.py
+++ b/tests/selenium/window_utils.py
@@ -1,74 +1,81 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
-#######################################################################################
+###############################################################################
 #
 # A collection of helper functions to manage tabs. Driver is an instance of
 # ChromeDriver.
 #
-#######################################################################################
+###############################################################################
 
 import time
 
-def switch_to_window_with_url( driver, url, max_tries=20 ):
-	"""Point the driver to the first window that matches this url."""
-	for i in range( max_tries ):
-		#print "switch to window with url " + url + " try number " + str(i)
-		windows = get_windows_with_url( driver, url )
-		if len(windows) > 0:
-			# if multiple tabs point at this url, switch to the first one
-			driver.switch_to.window( windows[0] )
-			return
-		time.sleep(1)
-	raise Exception("was not able to find window for url " + url )
 
-def refresh_window_with_url( driver, url, max_tries=20 ):
-	"""Have the driver redresh the first window that matches this url"""
-	for i in range( max_tries ):
-		#print "switch to window with url " + url + " try number " + str(i)
-		windows = get_windows_with_url( driver, url )
-		if len(windows) > 0:
-			# if multiple tabs point at this url, refresh to the first one
-			driver.switch_to.window( windows[0] )
-			driver.refresh()
-			return
-		time.sleep(1)
-	raise Exception("was not able to find window for url " + url )
+def switch_to_window_with_url(driver, url, max_tries=20):
+    """Point the driver to the first window that matches this url."""
+    for _ in range(max_tries):
+        # print "switch to window with url " + url + " try number " + str(i)
+        windows = get_windows_with_url(driver, url)
+        if len(windows) > 0:
+            # if multiple tabs point at this url, switch to the first one
+            driver.switch_to.window(windows[0])
+            return
+        time.sleep(1)
+    raise Exception("was not able to find window for url " + url)
 
 
-def close_windows_with_url(driver, url, max_tries=20 ):
-	"""Find all the tabs with the given url and close them. Note: if there are no 
-	more windows left this will close the browser too."""
-	for i in range( max_tries ):
-		#print "close windows with url " + url + " try number " + str(i)
-		windows = get_windows_with_url( driver, url )
-		if len(windows) > 0:
-			#print "closing " + str(len(windows)) + " windows "
-			[close_window(driver,w) for w in windows]
-			if len( driver.window_handles ) > 0:
-				driver.switch_to.window( driver.window_handles[0] )
-			return
-		time.sleep(1)
-	raise Exception("was not able to find window for url " + url )
+def refresh_window_with_url(driver, url, max_tries=20):
+    """Have the driver redresh the first window that matches this url"""
+    for _ in range(max_tries):
+        # print "switch to window with url " + url + " try number " + str(i)
+        windows = get_windows_with_url(driver, url)
+        if len(windows) > 0:
+            # if multiple tabs point at this url, refresh to the first one
+            driver.switch_to.window(windows[0])
+            driver.refresh()
+            return
+        time.sleep(1)
+    raise Exception("was not able to find window for url " + url)
 
-def get_windows_with_url( driver, url ):
-	"""Get a list of existing windows that match the url."""
-	windows = []
-	for w in driver.window_handles:
-		driver.switch_to.window( w )
-		if driver.current_window_handle != w:
-			#print "target window " + w + " current window " + driver.current_window_handle
-			raise Exception("window handles don't match!")
-		# current_url might have a trailing slash on it, so try it both ways
-		alt_url = url
-		if alt_url[-1] != '/': alt_url += '/'
-		#print "\tget_windows_with_url " + url + ": looking at " + driver.current_url
-		if driver.current_url == url or driver.current_url == alt_url:
-			#print "\tfound a match"
-			windows.append( w )
-	return windows
 
-def close_window( driver, w ):
-	"""Close the window associated with the given window handle."""
-	driver.switch_to.window(w)
-	return driver.close()
+def close_windows_with_url(driver, url, max_tries=20):
+    """Find all the tabs with the given url and close them. Note: if there
+    are no more windows left this will close the browser too."""
+    for _ in range(max_tries):
+        # print "close windows with url " + url + " try number " + str(i)
+        windows = get_windows_with_url(driver, url)
+        if len(windows) > 0:
+            # print "closing " + str(len(windows)) + " windows "
+            [close_window(driver, w) for w in windows]
+            if len(driver.window_handles) > 0:
+                driver.switch_to.window(driver.window_handles[0])
+            return
+        time.sleep(1)
+    raise Exception("was not able to find window for url " + url)
+
+
+def get_windows_with_url(driver, url):
+    """Get a list of existing windows that match the url."""
+    windows = []
+    for w in driver.window_handles:
+        driver.switch_to.window(w)
+        if driver.current_window_handle != w:
+            # print "target window " + w + " current window " +\
+            # driver.current_window_handle
+            raise Exception("window handles don't match!")
+        # current_url might have a trailing slash on it, so try it both ways
+        alt_url = url
+        if alt_url[-1] != '/':
+            alt_url += '/'
+        # print "\tget_windows_with_url " + url + ": looking at " +\
+        # driver.current_url
+        if driver.current_url == url or driver.current_url == alt_url:
+            # print "\tfound a match"
+            windows.append(w)
+    return windows
+
+
+def close_window(driver, w):
+    """Close the window associated with the given window handle."""
+    driver.switch_to.window(w)
+    return driver.close()


### PR DESCRIPTION
- Fix: frequent chromedriver hangs during driver initialization (crbug.com/309093).
This prevents Travis errors where the test hangs with the following log:
`No output has been received in the last 10m0s,...The build has been terminated`.

- Wait until the alert is present after removing an origin.
  Fixes infrequent selenium errors related to alert handling.
- Use travis_retry to retry failed CI tests.
- Refactor setup_travis.sh.
- Search for chromedriver in the PATH.
- Use gistcdn.githack.com instead of jsfiddle.
  It loads faster and doesn't contain 3rd party clutter.
- Use pbtest.org instead of nytimes.com in the tooltip test.
- Don't start a (second) virtual display on Travis.
  We already start an Xvfb instance in the .travis.yml
- Fix PEP8 warnings.
- Fix indentation and mixed tab-space warnings.
- Add a method to reliably load the options page.
- Report the slowest tests using py.test's `--durations` argument.

Should fix #924.