### PR TITLE
Run Travis tests for Chrome beta channel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,33 @@ os: linux
 dist: trusty
 python:
   - "2.7"
+env:
+  matrix:
+    - TRAVIS_EXTRA_JOB_WORKAROUND=true
+matrix:
+  fast_finish: true
+  include:
+    - python: "2.7"
+      env: CHROME="google-chrome-stable"
+    - python: "2.7"
+      env: CHROME_PATH="google-chrome-beta"
+  allow_failures:
+    - python: "2.7"
+      env: CHROME_PATH="google-chrome-beta"
+  exclude:
+    - env: TRAVIS_EXTRA_JOB_WORKAROUND=true
 addons:
   apt:
     sources:
     - google-chrome
     packages:
     - google-chrome-stable
+    - google-chrome-beta
     - python-virtualenv
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 before_script:
-  - ./scripts/setup_travis.sh
+  - . ./scripts/setup_travis.sh
   - cd tests
 script:  travis_retry ./run_selenium_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   include:
     - python: "2.7"
       env: CHROME="google-chrome-stable"
+    - python: "3.4"
+      env: CHROME="google-chrome-stable"
     - python: "2.7"
       env: CHROME_PATH="google-chrome-beta"
   allow_failures:

--- a/scripts/setup_travis.sh
+++ b/scripts/setup_travis.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# Install chromedriver
 
+# Install the latest version of the chromedriver
 latest_version=$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)
 wget -O /tmp/chromedriver.zip "https://chromedriver.storage.googleapis.com/${latest_version}/chromedriver_linux64.zip"
 sudo unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
 sudo chmod a+x /usr/local/bin/chromedriver
+
+# Set the path to the browser binary we want to test against
+export BROWSER_BIN=`which ${CHROME_PATH}`

--- a/tests/run_selenium_tests.sh
+++ b/tests/run_selenium_tests.sh
@@ -15,9 +15,10 @@ pip install -r sel_requirements.txt
 # TODO: take command line arguments to set the following environment variables
 export PB_EXT_PATH=$ext_path  # extension on this path will be used in the tests
 # if this var is empty, extension base dir will be searched for the last modified .crx.
-export BROWSER_BIN=""   # Path to the browser binary. Optional.
-# If empty, Selenium will pick the default binary for the selected browser.
-# To run tests with Chromium (instead of default Google Chrome) export BROWSER_BIN="/usr/bin/chromium-browser"
+echo "Chrome path: "$BROWSER_BIN
+# export BROWSER_BIN="/path/to/chrome"   # Optional.
+# If BROWSER_BIN is empty, Selenium will pick the default binary for Chrome.
+# To run tests with Chromium (instead of Google Chrome) export BROWSER_BIN="/usr/bin/chromium-browser"
 export ENABLE_XVFB=1    # run the tests headless using Xvfb. Set 0 to disable
 # for i in {1..20}; do echo "Run "$i; py.test -s -v --durations=10 selenium; done  # autodiscover and run the tests
 py.test -s -v --durations=10 selenium  # autodiscover and run the tests

--- a/tests/run_selenium_tests.sh
+++ b/tests/run_selenium_tests.sh
@@ -7,9 +7,9 @@ make  # pack the extension
 ext_path=`ls -1tr $PWD/*.crx | tail -n 1` # get the last modified crx
 popd
 
-trap 'rm -rf PBTESTENV' EXIT  # Clean virtualenv dir on exit
-virtualenv PBTESTENV
-source PBTESTENV/bin/activate
+# trap 'rm -rf PBTESTENV' EXIT  # Clean virtualenv dir on exit
+# virtualenv PBTESTENV
+# source PBTESTENV/bin/activate
 pip install -r sel_requirements.txt
 
 # TODO: take command line arguments to set the following environment variables

--- a/tests/selenium/localstorage_test.py
+++ b/tests/selenium/localstorage_test.py
@@ -36,7 +36,6 @@ class LocalStorageTest(pbtest.PBSeleniumTest):
         get_dnt_hashes =\
             "return (pb.storage.getBadgerStorageObject('dnt_hashes')."\
             "getItemClones())"
-        print self.js("return pb.storage.getBadgerStorageObject('dnt_hashes')")
         policy_hashes = self.js(get_dnt_hashes)
         for policy_hash in policy_hashes.keys():
             self.assertEqual(PB_POLICY_HASH_LEN, len(policy_hash))

--- a/tests/selenium/super_cookie_test.py
+++ b/tests/selenium/super_cookie_test.py
@@ -29,7 +29,7 @@ class SuperCookieTest(pbtest.PBSeleniumTest):
                       wait_on_site=5)
         self.driver.switch_to_frame(self.driver.
                                     find_element_by_tag_name("iframe"))
-        print self.js("return localStorage['frameId']")
+        print(self.js("return localStorage['frameId']"))
         self.assertTrue(self.has_supercookies("githack.com"))
 
     def test_should_not_detect_low_entropy_ls_of_third_party_frame(self):


### PR DESCRIPTION
Allow failures for the beta version.
Enable fast finishing.

Run tests with Python 3.4.
Fix https://github.com/EFForg/privacybadgerchrome/issues/937 by updating the print statements in the tests.

Don't create a virtual environment for the tests. Travis already creates one.
We can't seem to use the right Python (3) version if we create the virtual env. ourselves.

Remove redundant printing of the downloaded PB policy.