### PR TITLE
Block ping requests sent by navigator.sendBeacon (issue #587).

### DIFF
--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -55,6 +55,13 @@ function onBeforeRequest(details){
     recordFrame(details.tabId, details.frameId, details.parentFrameId, details.url);
   }
 
+  // Block ping requests sent by navigator.sendBeacon (see, #587)
+  // tabId for pings are always -1 due to Chrome bugs #522124 and #522129
+  // Once these bugs are fixed, PB will treat pings as any other request
+  if (type == "ping" && details.tabId < 0 ){
+    return {cancel: true};
+  }
+
   if ( _isTabChromeInternal(details.tabId)){
     return {};
   }


### PR DESCRIPTION
Until the following Chrome bugs are fixed and landed
PB can't know which tab or frame is the initiator of the ping
request. So PB will block all ping requests, even when it's
disabled on the site that sent the ping:

- https://crbug.com/522124 (landed in the Chrome unstable)
- https://crbug.com/522129

Once these bugs are landed, PB will treat the ping requests
as any other request and will block only when it's enabled for the
current tab.

This is tested with the Chrome unstable, where the fix
for bug-522124 is landed: since the tabId and frameId for the ping
requests are available, PB honors the disabled status and uses the
same blocking logic as the other requests.

Tested manually with Wireshark and debug logging from the extension.
Fixes #587