### PR TITLE
Localize tracker tooltips

### DIFF
--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -129,6 +129,15 @@
     "show_counter_checkbox": {
         "message": "Show count of blocked items"
     },
+    "tooltip_allow": {
+        "message": "Move the slider right to allow a domain"
+    },
+    "tooltip_block": {
+        "message": "Move the slider left to block a domain"
+    },
+    "tooltip_cookieblock": {
+        "message": "Center the slider to block cookies"
+    },
     "whitelisted_domains": {
         "description": "This is a tab heading.",
         "message": "Whitelisted domains"

--- a/src/htmlutils.js
+++ b/src/htmlutils.js
@@ -91,18 +91,27 @@ var htmlUtils = exports.htmlUtils = {
   },
 
   /**
-   * Get HTML for tracker tooltips.
+   * Get HTML for tracker container.
+   *
+   * @param {Integer} tabId ID of tab trackers are associated with.
+   * @returns {String} HTML for empty tracker container.
    */
-  getTrackerTooltipHtml: function() {
-    var tooltipHtml = '' +
+  getTrackerContainerHtml: function(tabId) {
+    if (tabId === undefined) {
+      tabId = "000"
+    }
+    var trackerHtml = '' +
+      '<div id="associatedTab" data-tab-id="' + tabId + '"></div>' +
       '<div class="keyContainer">' +
       '<div class="key">' +
       '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="' + i18n.getMessage("tooltip_block") + '">' +
       '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="' + i18n.getMessage("tooltip_cookieblock") + '">' +
       '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="' + i18n.getMessage("tooltip_allow") + '">' +
       '<div class="tooltipContainer"></div>' +
-      '</div></div>';
-    return tooltipHtml;
+      '</div></div>' +
+      '<div class="spacer"></div>' +
+      '<div id="blockedResourcesInner" class="clickerContainer"></div>';
+    return trackerHtml;
   },
 
   /**

--- a/src/htmlutils.js
+++ b/src/htmlutils.js
@@ -91,6 +91,21 @@ var htmlUtils = exports.htmlUtils = {
   },
 
   /**
+   * Get HTML for tracker tooltips.
+   */
+  getTrackerTooltipHtml: function() {
+    var tooltipHtml = '' +
+      '<div class="keyContainer">' +
+      '<div class="key">' +
+      '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="' + i18n.getMessage("tooltip_block") + '">' +
+      '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="' + i18n.getMessage("tooltip_cookieblock") + '">' +
+      '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="' + i18n.getMessage("tooltip_allow") + '">' +
+      '<div class="tooltipContainer"></div>' +
+      '</div></div>';
+    return tooltipHtml;
+  },
+
+  /**
    * Adds HTML for given origin to existing HTML.
    *
    * @param {String} existingHtml Existing HTML to append origin HTML to.

--- a/src/options.js
+++ b/src/options.js
@@ -222,14 +222,9 @@ function refreshFilterPage() {
   $("#count").text(allTrackingDomains.length);
 
   // Display tracker tooltips.
-  var trackerTooltips = '<div id="associatedTab" data-tab-id="000"></div>' +
-    '<div class="keyContainer">'+
-    '<div class="key">'+
-    '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="' + i18n.getMessage("tooltip_block") + '">' +
-    '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="' + i18n.getMessage("tooltip_cookieblock") + '">' +
-    '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="' + i18n.getMessage("tooltip_allow") + '">' +
-    '<div class="tooltipContainer"></div>' +
-    '</div></div>'+
+  var trackerTooltips = '' +
+    '<div id="associatedTab" data-tab-id="000"></div>' +
+    htmlUtils.getTrackerTooltipHtml() +
     '<div class="spacer"></div>' +
     '<div id="blockedResourcesInner" class="clickerContainer"></div>';
   $("#blockedResources").html(trackerTooltips);

--- a/src/options.js
+++ b/src/options.js
@@ -225,9 +225,9 @@ function refreshFilterPage() {
   var trackerTooltips = '<div id="associatedTab" data-tab-id="000"></div>' +
     '<div class="keyContainer">'+
     '<div class="key">'+
-    '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="Move the slider left to block a domain.">'+
-    '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="Center the slider to block cookies.">'+
-    '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="Move the slider right to allow a domain.">'+
+    '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="' + i18n.getMessage("tooltip_block") + '">' +
+    '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="' + i18n.getMessage("tooltip_cookieblock") + '">' +
+    '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="' + i18n.getMessage("tooltip_allow") + '">' +
     '<div class="tooltipContainer"></div>' +
     '</div></div>'+
     '<div class="spacer"></div>' +

--- a/src/options.js
+++ b/src/options.js
@@ -222,12 +222,7 @@ function refreshFilterPage() {
   $("#count").text(allTrackingDomains.length);
 
   // Display tracker tooltips.
-  var trackerTooltips = '' +
-    '<div id="associatedTab" data-tab-id="000"></div>' +
-    htmlUtils.getTrackerTooltipHtml() +
-    '<div class="spacer"></div>' +
-    '<div id="blockedResourcesInner" class="clickerContainer"></div>';
-  $("#blockedResources").html(trackerTooltips);
+  $("#blockedResources").html(htmlUtils.getTrackerContainerHtml());
 
   // Display tracking domains.
   var originsToDisplay;

--- a/src/popup.js
+++ b/src/popup.js
@@ -268,11 +268,16 @@ function refreshPopup(tabId) {
     $('#number_trackers').text('0');
     return;
   }
-  var printable = '' +
+
+  // Display tracker tooltips.
+  var trackerTooltips = '' +
     '<div id="associatedTab" data-tab-id="' + tabId + '"></div>' +
     htmlUtils.getTrackerTooltipHtml() +
     '<div class="spacer"></div>' +
-    '<div class="clickerContainer">';
+    '<div id="blockedResourcesInner" class="clickerContainer"></div>';
+  $("#blockedResources").html(trackerTooltips);
+
+  var printable = '';
   var nonTracking = [];
   origins.sort(htmlUtils.compareReversedDomains);
   var originCount = 0;
@@ -323,9 +328,8 @@ function refreshPopup(tabId) {
     }
   }
   $('#number_trackers').text(originCount);
-  printable += "</div>";
-  $("#blockedResources").empty();
-  $("#blockedResources").html(printable);
+  $("#blockedResourcesInner").html(printable);
+
   $('.switch-toggle').each(function(){
     var radios = $(this).children('input');
     var value = $(this).children('input:checked').val();

--- a/src/popup.js
+++ b/src/popup.js
@@ -270,12 +270,7 @@ function refreshPopup(tabId) {
   }
 
   // Display tracker tooltips.
-  var trackerTooltips = '' +
-    '<div id="associatedTab" data-tab-id="' + tabId + '"></div>' +
-    htmlUtils.getTrackerTooltipHtml() +
-    '<div class="spacer"></div>' +
-    '<div id="blockedResourcesInner" class="clickerContainer"></div>';
-  $("#blockedResources").html(trackerTooltips);
+  $("#blockedResources").html(htmlUtils.getTrackerContainerHtml(tabId));
 
   var printable = '';
   var nonTracking = [];

--- a/src/popup.js
+++ b/src/popup.js
@@ -268,16 +268,11 @@ function refreshPopup(tabId) {
     $('#number_trackers').text('0');
     return;
   }
-  var printable = '<div id="associatedTab" data-tab-id="' + tabId + '"></div>';
-  printable = printable +
-  '<div class="keyContainer">'+
-  '<div class="key">'+
-  '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="' + i18n.getMessage("tooltip_block") + '">' +
-  '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="' + i18n.getMessage("tooltip_cookieblock") + '">' +
-  '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="' + i18n.getMessage("tooltip_allow") + '">' +
-  '<div class="tooltipContainer"></div>' +
-  '</div></div>'+
-  '<div class="spacer"></div><div class="clickerContainer">';
+  var printable = '' +
+    '<div id="associatedTab" data-tab-id="' + tabId + '"></div>' +
+    htmlUtils.getTrackerTooltipHtml() +
+    '<div class="spacer"></div>' +
+    '<div class="clickerContainer">';
   var nonTracking = [];
   origins.sort(htmlUtils.compareReversedDomains);
   var originCount = 0;

--- a/src/popup.js
+++ b/src/popup.js
@@ -272,9 +272,9 @@ function refreshPopup(tabId) {
   printable = printable +
   '<div class="keyContainer">'+
   '<div class="key">'+
-  '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="Move the slider left to block a domain.">'+
-  '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="Center the slider to block cookies.">'+
-  '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="Move the slider right to allow a domain.">'+
+  '<img class="tooltip" src="/icons/UI-icons-red.png" tooltip="' + i18n.getMessage("tooltip_block") + '">' +
+  '<img class="tooltip" src="/icons/UI-icons-yellow.png" tooltip="' + i18n.getMessage("tooltip_cookieblock") + '">' +
+  '<img class="tooltip" src="/icons/UI-icons-green.png" tooltip="' + i18n.getMessage("tooltip_allow") + '">' +
   '<div class="tooltipContainer"></div>' +
   '</div></div>'+
   '<div class="spacer"></div><div class="clickerContainer">';

--- a/tests/selenium/options_test.py
+++ b/tests/selenium/options_test.py
@@ -45,9 +45,9 @@ class OptionsPageTest(pbtest.PBSeleniumTest):
     def test_should_display_tooltips_on_hover(self):
         driver = self.driver
         find_el_by_css = self.find_el_by_css  # find with WebDriver wait
-        TOOLTIP_TXTS = ("Move the slider left to block a domain.",
-                        "Center the slider to block cookies.",
-                        "Move the slider right to allow a domain.")
+        TOOLTIP_TXTS = ("Move the slider left to block a domain",
+                        "Center the slider to block cookies",
+                        "Move the slider right to allow a domain")
         # Add a tracking domain
         self.add_test_origin("pbtest.org", "block")
         self.load_options_page()

--- a/tests/tests/htmlutils.js
+++ b/tests/tests/htmlutils.js
@@ -115,6 +115,19 @@
     }
   });
 
+  test("getTrackerContainerHtml", function() {
+    // Test given tab ID.
+    var tabId = 1;
+    var htmlResult = htmlUtils.getTrackerContainerHtml(tabId);
+    var tabIdExists = htmlResult.indexOf('data-tab-id="' + tabId + '"') > -1;
+    ok(tabIdExists, "Given tab ID should be set");
+
+    // Test missing tab ID.
+    htmlResult = htmlUtils.getTrackerContainerHtml();
+    var defaultTabIdExists = htmlResult.indexOf('data-tab-id="000"') > -1;
+    ok(defaultTabIdExists, "Default tab ID should be set")
+  });
+
   test("addOriginHtml", function() {
     // Test parameters
     var tests = [


### PR DESCRIPTION
This addresses the missing localization mentioned issue #830. I also ended up doing a little refactoring with some of the related HTML code for the popup and options page. Of course there's a lot more refactoring to do but that would probably be best in a separate PR.

**Note**: issue #830 should probably be re-opened if this is merged. I wasn't thinking and my first commit closes the issue. This PR adds the ability to localize the tooltips but doesn't add the missing translations.