### PR TITLE
Fix options page tracker list

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -278,7 +278,7 @@ function showTrackingDomains(domains) {
   domains.sort(htmlUtils.compareReversedDomains);
 
   // Create HTML for list of tracking domains.
-  var trackingDetails = '<div id="blockedResourcesInner" class="clickerContainer">';
+  var trackingDetails = '';
   for (var i = 0; i < domains.length; i++) {
     var trackingDomain = domains[i];
     // todo: gross hack, use templating framework


### PR DESCRIPTION
This fixes an issue with the options page caused by a duplicate div.

**Before**:
![screenshot at 2016-10-02 16 05 53](https://cloud.githubusercontent.com/assets/873661/19023319/39effc4a-88ba-11e6-88a8-8745ded8ba4a.png)

**After**:
![screenshot at 2016-10-02 16 04 24](https://cloud.githubusercontent.com/assets/873661/19023322/3eccab96-88ba-11e6-9384-d6bcebb1e157.png)
