### PR TITLE
Changing to check for length in cases where list is 'undefined'

### DIFF
--- a/src/socialwidgets.js
+++ b/src/socialwidgets.js
@@ -287,7 +287,7 @@ function replaceInitialTrackerButtonsHelper(trackerButtonsToReplace) {
  * Individually replaces tracker buttons blocked after initial check.
  */
 function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
-  if (trackerInfo.length === 0) { return; }
+  if (trackerInfo === undefined || trackerInfo.length === 0) { return; }
   trackerInfo.forEach(function(tracker) {
     var replaceTrackerButtons = (tracker.domain == trackerDomain);
     if (replaceTrackerButtons) {

--- a/src/socialwidgets.js
+++ b/src/socialwidgets.js
@@ -287,7 +287,7 @@ function replaceInitialTrackerButtonsHelper(trackerButtonsToReplace) {
  * Individually replaces tracker buttons blocked after initial check.
  */
 function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
-  if (trackerInfo === undefined || trackerInfo.length === 0) { return; }
+  if (!trackerInfo) { return; }
   trackerInfo.forEach(function(tracker) {
     var replaceTrackerButtons = (tracker.domain == trackerDomain);
     if (replaceTrackerButtons) {

--- a/src/socialwidgets.js
+++ b/src/socialwidgets.js
@@ -287,7 +287,7 @@ function replaceInitialTrackerButtonsHelper(trackerButtonsToReplace) {
  * Individually replaces tracker buttons blocked after initial check.
  */
 function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
-  if (trackerInfo === null) { return; }
+  if (trackerInfo.length === 0) { return; }
   trackerInfo.forEach(function(tracker) {
     var replaceTrackerButtons = (tracker.domain == trackerDomain);
     if (replaceTrackerButtons) {


### PR DESCRIPTION
This is a fix for #920. When an array has length 0, its value is not `null`, so the check to exit early was not functional.