### PR TITLE
Protect against WebRTC leaking private IP address

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -158,7 +158,7 @@ Badger.prototype = {
 
   /**
    * Initialize the Cookieblock List:
-   * * Download list form eff
+   * * Download list from eff
    * * Merge with existing cookieblock list if any
    * * Add any new domains to the action map
    * Set a timer to update every 24 hours
@@ -168,12 +168,20 @@ Badger.prototype = {
     setInterval(this.updateCookieBlockList, utils.oneDay());
   },
 
+  /**
+   * (Currently Chrome only)
+   * Change default WebRTC handling browser policy to more
+   * private setting that only shows public facing IP address.
+   * Only update if user does not have the strictest setting enabled
+  **/
   enableWebRTCProtection: function(){
     var cpn = chrome.privacy.network;
     cpn.webRTCIPHandlingPolicy.get({}, function(result) {
-      // Only update value if stronger setting is not already active
-      if (result.value !== 'disable_non_proxied_udp') {
-        cpn.webRTCIPHandlingPolicy.set({ value: 'default_public_interface_only'},
+      if (result.value === 'disable_non_proxied_udp') {
+        return; // Current setting is stricter than our preferred setting
+      }
+
+      cpn.webRTCIPHandlingPolicy.set({ value: 'default_public_interface_only'},
             function(){ // empty callback
             });
       }

--- a/src/background.js
+++ b/src/background.js
@@ -175,7 +175,7 @@ Badger.prototype = {
       if (result.value !== 'disable_non_proxied_udp') {
         cpn.webRTCIPHandlingPolicy.set({ value: 'default_public_interface_only'},
             function(){ // empty callback
-            })
+            });
       }
     });
   },
@@ -373,100 +373,6 @@ Badger.prototype = {
       settings.setItem('migrationLevel', i+1);
     }
 
-  },
-
-  // Calling with `true` means IP address leak is not prevented.
-  // https://github.com/gorhill/uBlock/issues/533
-  //   We must first check wether this Chromium-based browser was compiled
-  //   with WebRTC support. To do this, we use an iframe, this way the
-  //   empty RTCPeerConnection object we create to test for support will
-  //   be properly garbage collected. This prevents issues such as
-  //   a computer unable to enter into sleep mode, as reported in the
-  //   Chrome store:
-  // https://github.com/gorhill/uBlock/issues/533#issuecomment-167931681
-  setWebrtcIPAddress: function(setting) {
-    // We don't know yet whether this browser supports WebRTC: find out.
-    if ( this.webRTCSupported === undefined ) {
-      this.webRTCSupported = { setting: setting };
-      var iframe = document.createElement('iframe');
-      var me = this;
-      var messageHandler = function(ev) {
-        if ( ev.origin !== self.location.origin ) {
-          return;
-        }
-        window.removeEventListener('message', messageHandler);
-        var setting = me.webRTCSupported.setting;
-        me.webRTCSupported = ev.data === 'webRTCSupported';
-        me.setWebrtcIPAddress(setting);
-        iframe.parentNode.removeChild(iframe);
-        iframe = null;
-      };
-      window.addEventListener('message', messageHandler);
-      iframe.src = 'is-webrtc-supported.html';
-      document.body.appendChild(iframe);
-      return;
-    }
-
-    // We are waiting for a response from our iframe. This makes the code
-    // safe to re-entrancy.
-    if ( typeof this.webRTCSupported === 'object' ) {
-      this.webRTCSupported.setting = setting;
-      return;
-    }
-
-    // https://github.com/gorhill/uBlock/issues/533
-    // WebRTC not supported: `webRTCMultipleRoutesEnabled` can NOT be
-    // safely accessed. Accessing the property will cause full browser
-    // crash.
-    if ( this.webRTCSupported !== true ) {
-      return;
-    }
-
-    var cp = chrome.privacy,
-        cpn = cp.network;
-
-    // Older version of Chromium do not support this setting, and is
-    // marked as "deprecated" since Chromium 48.
-    if ( typeof cpn.webRTCMultipleRoutesEnabled === 'object' ) {
-      try {
-        if ( setting ) {
-          cpn.webRTCMultipleRoutesEnabled.clear({
-            scope: 'regular'
-          }, this.noopCallback);
-        } else {
-          cpn.webRTCMultipleRoutesEnabled.set({
-            value: false,
-            scope: 'regular'
-          }, this.noopCallback);
-        }
-      } catch(ex) {
-        console.error(ex);
-      }
-    }
-
-    // This setting became available in Chromium 48.
-    if ( typeof cpn.webRTCIPHandlingPolicy === 'object' ) {
-      try {
-        if ( setting ) {
-          cpn.webRTCIPHandlingPolicy.clear({
-            scope: 'regular'
-          }, this.noopCallback);
-        } else {
-          // Respect current stricter setting if any.
-          cpn.webRTCIPHandlingPolicy.get({}, function(details) {
-            var value = details.value === 'disable_non_proxied_udp' ?
-                'disable_non_proxied_udp' :
-                'default_public_interface_only';
-            cpn.webRTCIPHandlingPolicy.set({
-              value: value,
-              scope: 'regular'
-            }, this.noopCallback);
-          }.bind(this));
-        }
-      } catch(ex) {
-        console.error(ex);
-      }
-    }
   },
 
 

--- a/src/background.js
+++ b/src/background.js
@@ -183,7 +183,7 @@ Badger.prototype = {
 
       cpn.webRTCIPHandlingPolicy.set({ value: 'default_public_interface_only'},
         function(){ // empty callback
-          });
+        });
     });
   },
 

--- a/src/background.js
+++ b/src/background.js
@@ -26,7 +26,7 @@ var pbStorage = require("storage");
 
 var HeuristicBlocking = require("heuristicblocking");
 var webrequest = require("webrequest");
-
+//var webrtc = require("webrtc");
 var SocialWidgetLoader = require("socialwidgetloader");
 window.SocialWidgetList = SocialWidgetLoader.loadSocialWidgetsFromFile("data/socialwidgets.json");
 
@@ -66,6 +66,160 @@ function Badger() {
 
     badger.INITIALIZED = true;
   });
+  this.webrtc = {
+    webRTCSupported: undefined,
+
+    // https://github.com/gorhill/uBlock/issues/875
+    // Must not leave `lastError` unchecked.
+    noopCallback: function() {
+      void chrome.runtime.lastError;
+    },
+
+    // Calling with `true` means IP address leak is not prevented.
+    // https://github.com/gorhill/uBlock/issues/533
+    //   We must first check wether this Chromium-based browser was compiled
+    //   with WebRTC support. To do this, we use an iframe, this way the
+    //   empty RTCPeerConnection object we create to test for support will
+    //   be properly garbage collected. This prevents issues such as
+    //   a computer unable to enter into sleep mode, as reported in the
+    //   Chrome store:
+    // https://github.com/gorhill/uBlock/issues/533#issuecomment-167931681
+    setWebrtcIPAddress: function(setting) {
+      // We don't know yet whether this browser supports WebRTC: find out.
+      if ( this.webRTCSupported === undefined ) {
+        this.webRTCSupported = { setting: setting };
+        var iframe = document.createElement('iframe');
+        var me = this;
+        var messageHandler = function(ev) {
+          if ( ev.origin !== self.location.origin ) {
+            return;
+          }
+          window.removeEventListener('message', messageHandler);
+          var setting = me.webRTCSupported.setting;
+          me.webRTCSupported = ev.data === 'webRTCSupported';
+          me.setWebrtcIPAddress(setting);
+          iframe.parentNode.removeChild(iframe);
+          iframe = null;
+        };
+        window.addEventListener('message', messageHandler);
+        iframe.src = 'src/is-webrtc-supported.html';
+        document.body.appendChild(iframe);
+        return;
+      }
+
+      // We are waiting for a response from our iframe. This makes the code
+      // safe to re-entrancy.
+      if ( typeof this.webRTCSupported === 'object' ) {
+        this.webRTCSupported.setting = setting;
+        return;
+      }
+
+      // https://github.com/gorhill/uBlock/issues/533
+      // WebRTC not supported: `webRTCMultipleRoutesEnabled` can NOT be
+      // safely accessed. Accessing the property will cause full browser
+      // crash.
+      if ( this.webRTCSupported !== true ) {
+        return;
+      }
+
+      var cp = chrome.privacy,
+          cpn = cp.network;
+
+      // Older version of Chromium do not support this setting, and is
+      // marked as "deprecated" since Chromium 48.
+      if ( typeof cpn.webRTCMultipleRoutesEnabled === 'object' ) {
+        try {
+          if ( setting ) {
+            cpn.webRTCMultipleRoutesEnabled.clear({
+              scope: 'regular'
+            }, this.noopCallback);
+          } else {
+            cpn.webRTCMultipleRoutesEnabled.set({
+              value: false,
+              scope: 'regular'
+            }, this.noopCallback);
+          }
+        } catch(ex) {
+          console.error(ex);
+        }
+      }
+
+      // This setting became available in Chromium 48.
+      if ( typeof cpn.webRTCIPHandlingPolicy === 'object' ) {
+        try {
+          if ( setting ) {
+            cpn.webRTCIPHandlingPolicy.clear({
+              scope: 'regular'
+            }, this.noopCallback);
+          } else {
+            // Respect current stricter setting if any.
+            cpn.webRTCIPHandlingPolicy.get({}, function(details) {
+              var value = details.value === 'disable_non_proxied_udp' ?
+                  'disable_non_proxied_udp' :
+                  'default_public_interface_only';
+              cpn.webRTCIPHandlingPolicy.set({
+                value: value,
+                scope: 'regular'
+              }, this.noopCallback);
+            }.bind(this));
+          }
+        } catch(ex) {
+          console.error(ex);
+        }
+      }
+    },
+
+    set: function(details) {
+      for ( var setting in details ) {
+        if ( details.hasOwnProperty(setting) === false ) {
+          continue;
+        }
+        switch ( setting ) {
+          case 'prefetching':
+            try {
+              if ( !!details[setting] ) {
+                chrome.privacy.network.networkPredictionEnabled.clear({
+                  scope: 'regular'
+                }, this.noopCallback);
+              } else {
+                chrome.privacy.network.networkPredictionEnabled.set({
+                  value: false,
+                  scope: 'regular'
+                }, this.noopCallback);
+              }
+            } catch(ex) {
+              console.error(ex);
+            }
+            break;
+
+          case 'hyperlinkAuditing':
+            try {
+              if ( !!details[setting] ) {
+                chrome.privacy.websites.hyperlinkAuditingEnabled.clear({
+                  scope: 'regular'
+                }, this.noopCallback);
+              } else {
+                chrome.privacy.websites.hyperlinkAuditingEnabled.set({
+                  value: false,
+                  scope: 'regular'
+                }, this.noopCallback);
+              }
+            } catch(ex) {
+              console.error(ex);
+            }
+            break;
+
+          case 'webrtcIPAddress':
+            this.setWebrtcIPAddress(!!details[setting]);
+            break;
+
+          default:
+            break;
+        }
+      }
+    }
+  };
+  this.webrtc.setWebrtcIPAddress(false);
 }
 
 Badger.prototype = {

--- a/src/background.js
+++ b/src/background.js
@@ -182,9 +182,8 @@ Badger.prototype = {
       }
 
       cpn.webRTCIPHandlingPolicy.set({ value: 'default_public_interface_only'},
-            function(){ // empty callback
-            });
-      }
+        function(){ // empty callback
+          });
     });
   },
 


### PR DESCRIPTION
@cooperq @ghostwords @pde Here's the updated implementation of WebRTC protection.

A few points of note:
1. Changing the setting to `default_public_interface_only` hides the local IP address.
2. Having this setting enabled doesn't in any way seem to effect the ability to use Google Hangouts, etc. (as per testing with Cooper)
3. In uBlock, the callback contains a call to check `chrome.runtime.lastError`, saying `lastError` needs to be checked or Chrome complains (see https://github.com/gorhill/uBlock/issues/875), but from my testing this doesn't seem to be an issue anymore.
4. There are 4 possible settings: `default`, `default_public_and_private_interface`, `default_public_interface_only` and `disable_non_proxied_udp`. I think that this last option might end up breaking some things, so the 3rd option seems safe. In case the user already has this fourth option selected, I've followed uBlock's approach and kept their setting as is.

You can test this on https://diafygi.github.io/webrtc-ips/ and https://ipleak.net/.
