### PR TITLE
Have Travis install the ESLint version specified in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 before_script:
-  - npm install eslint
+  - npm install # install JS dependencies (eslint) from package.json
   - . ./scripts/setup_travis.sh
   - cd tests
 script:  travis_retry ./run_selenium_tests.sh


### PR DESCRIPTION
As major ESLint updates will bring unexpected/backwards-compatibility breaking changes, we should standardize on a particular version of ESLint, specified in the [package.json](https://github.com/EFForg/privacybadgerchrome/blob/master/package.json) file.