### PR TITLE
return early if browser doesn't implement chrome.privacy

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -175,6 +175,8 @@ Badger.prototype = {
    * Only update if user does not have the strictest setting enabled
   **/
   enableWebRTCProtection: function(){
+    // Return early if browser doesn't implement chrome.privacy
+    if (!chrome.privacy) {return;}
     var cpn = chrome.privacy.network;
     cpn.webRTCIPHandlingPolicy.get({}, function(result) {
       if (result.value === 'disable_non_proxied_udp') {


### PR DESCRIPTION
Feel free to ignore this PR or make the changes manually yourself.

This doesn't implement WebRTC protection for Firefox, but it prevents Firefox from throwing an error.