### PR TITLE
Adding ability to import and export tracker list

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -26,6 +26,15 @@
     "firstRun_title": {
         "message": "Privacy Badger wurde installiert"
     },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
+    },
     "name": {
         "message": "Privacy Badger"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Dürfen "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "Privacy Badger schützt sie vor Trackern während Sie im Web surfen !"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger ist de-aktiviert für die unten aufgelisteten Domains. Sie können eine Domain hinzufügen, indem Sie entweder dass Privacy Badger Icon in der Adresszeile klicken oder die Domain (nicht die URL) im Eingabefeld eingeben und auf \"Domain hinzufügen\" klicken."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "Was ist kaputt ?"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "feed_the_badger_title": {
         "message": "klicken, um die Kontrolle dieses Trackers an Privacy Badger zu übergeben"
@@ -26,11 +32,17 @@
     "firstRun_title": {
         "message": "Privacy Badger wurde installiert"
     },
+    "import": {
+        "message": "Import"
+    },
     "import_select_file": {
         "message": "Please select a file to import."
     },
     "import_successful": {
         "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
     },
     "invalid_json": {
         "message": "Invalid JSON file."

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is disabled for the domains listed below. You can add a domain either via the Privacy Badger icon in the address bar or by typing the domain (not a URL) in the box and clicking the \"Add domain\" button."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "What's Wrong?"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "feed_the_badger_title": {
         "message": "click to return control of this tracker to Privacy Badger"
@@ -28,6 +34,21 @@
     },
     "first_run_text": {
         "message": "Learn how Privacy Badger protects your privacy."
+    },
+    "import": {
+        "message": "Import"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "Privacy Badger"

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Allowed "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "Privacy Badger protects you from trackers as you surf the web!"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Este dominio está desbloqueado, desliza para bloquearlo completamento o bloquear las cookies."
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "¡Privacy Badger te protege de rastreadores mientras surfeas por la web!"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger está deshabilitado para la lista de dominios que se muestran debajo. Puedes añadir un dominio ya sea mediante el icono de Privacy Badger en la barra de direcciones o escribiéndo el dominio (no la URL) en el recuadro y haciendo click en el botón \"Añadir dominio\"."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "¿Qué está mal?"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "feed_the_badger_title": {
         "message": "haz click para devolver el control de este rastreador a Privacy Badger"
@@ -28,6 +34,21 @@
     },
     "first_run_text": {
         "message": "¡Aprenda cómo Privacy Badger protege su privacidad."
+    },
+    "import": {
+        "message": "Import"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "Privacy Badger"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -17,15 +17,35 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger est désactivé pour les noms de domaine listés ci-dessous. Vous pouvez ajouter un nom de domaine soit par le biais de l'icone du Privacy Badger présente sur la barre d'adresse soit en tapant le nom de domaine (pas l'URL) dans la fenêtre en cliquant sur le bouton \"Ajouter un nom de domaine\"."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
      "message": "Qu'est ce qui ne va pas ?"
     },
-
+    "export_user_data": {
+        "message": "Export user data"
+    },
     "feed_the_badger_title": {
         "message": "cliquer pour laisser le contrôle de ce traqueur au Privacy Badger"
     },
     "firstRun_title": {
         "message": "Privacy Badger a été installé"
+    },
+    "import": {
+        "message": "Import"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "Privacy Badger"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Permis "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "Privacy Badger vous protège des traqueurs lorsque vous surfez sur le web !"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Permesso "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "Privacy Badger ti protegge dai tracker mentre navighi in rete!"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger è disabilitato per i domini elencati sotto. Puoi aggiungere un dominio usando l'icona di Privacy Badger nella barra indirizzi o digitando il dominio (non un URL) nella casella e cliccando il pulsante \"Aggiungi dominio\"."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "Che c'è che non va?"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "feed_the_badger_title": {
         "message": "clicca per restituire il controllo di questo tracker a Privacy Badger"
@@ -28,6 +34,21 @@
     },
     "first_run_text": {
         "message": "Scopri come Privacy Badger protegge la tua privacy."
+    },
+    "import": {
+        "message": "Import"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "Privacy Badger"

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Toegestaan "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "Privacy Badger geeft u meer controle over het gevolgd worden op internet!"
     },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger is uitgeschakeld voor de volgende (derde) partijen. U kunt een (derde) partij op twee manieren blokkeren, met het Privacy Badger pictogram in de adresbalk, of door de domeinnaam (niet de URL) in te typen en vervolgens de \"Partij toevoegen\"-knop aan te klikken."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "Wat ging er mis?"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "tooltip_allow": {
         "message": "Move the slider right to allow a domain"
@@ -34,6 +40,21 @@
     },
     "firstRun_title": {
         "message": "Dank u voor het installeren van Privacy Badger!"
+    },
+    "import": {
+        "message": "Import"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "Privacy Badger"

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Разрешен "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "Privacy Badger защищает вас от трекеров во время работы в Интернете!"
     },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger отключен для сайтов из списка, приведенного ниже. Вы можете добавить домен с помощью значка Privacy Badger в адресной строке или напечатать домен (НЕ URL) в текстовом поле и нажать кнопку «Добавить домен»."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "Что случилось?"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "feed_the_badger_title": {
         "message": "Щелкните, чтобы вернуть этот трекер под контроль Privacy Badger"
@@ -28,6 +34,21 @@
     },
     "first_run_text": {
         "message": "Узнайте, как Privacy Badger защищает вашу приватность."
+    },
+    "import": {
+        "message": "Import"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "Privacy Badger"

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "Tillåten "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "Privacy Badger skyddar dig mot spanare medan du surfar!"
     },

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "Privacy Badger är avaktiverad för domäner listade nedanför. Du kan lägga till domäner med Privacy Badger-ikonen i adressfältet eller genom att skriva in domänen (inte URL:en) i rutan och klicka på knappen \"Lägg till domän\"."
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "Hur står det till?"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "feed_the_badger_title": {
         "message": "klicka för att återge kontrollen av spanaren till Privacy Badger"
@@ -29,6 +35,9 @@
     "first_run_text": {
         "message": "Lär dig hur Privacy Badger skyddar din integritet."
     },
+    "import": {
+        "message": "Import"
+    },
     "tooltip_allow": {
         "message": "Move the slider right to allow a domain"
     },
@@ -37,6 +46,18 @@
     },
     "tooltip_cookieblock": {
         "message": "Center the slider to block cookies"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "Privacy Badger"

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -11,6 +11,9 @@
     "badger_status_noaction": {
         "message": "允许 "
     },
+    "data_settings": {
+        "message": "Manage Data"
+    },
     "description": {
         "message": "你在网上冲浪的时候，隐私獾会保护你免受跟踪器的烦恼！"
     },

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -17,8 +17,14 @@
     "disabled_for_these_domains": {
         "message": "隐私獾被禁用在以下域名。你可以通过点击地址栏的隐私獾图标单击“添加域名”按钮，在方框中输入域名（而不是URL）进行添加域名。"
     },
+    "download": {
+        "message": "Download"
+    },
     "error_input": {
         "message": "问题是什么？"
+    },
+    "export_user_data": {
+        "message": "Export user data"
     },
     "feed_the_badger_title": {
         "message": "点击以让隐私獾控制这个跟踪器的"
@@ -28,6 +34,21 @@
     },
     "first_run_text": {
         "message": "了解隐私獾如何保护你的隐私。"
+    },
+    "import": {
+        "message": "Import"
+    },
+    "import_select_file": {
+        "message": "Please select a file to import."
+    },
+    "import_successful": {
+        "message": "Tracker list and settings updated successfully!"
+    },
+    "import_user_data": {
+        "message": "Import user data"
+    },
+    "invalid_json": {
+        "message": "Invalid JSON file."
     },
     "name": {
         "message": "隐私獾"

--- a/manifest.json
+++ b/manifest.json
@@ -97,6 +97,9 @@
     "default_title": "__MSG_name__"
   },
   "options_page": "/skin/options.html",
+  "storage": {
+    "scripts": "lib/underscore-min.js"
+  },
   "update_url": "http://clients2.google.com/service/update2/crx",
   "web_accessible_resources": [
     "skin/*",

--- a/manifest.json
+++ b/manifest.json
@@ -97,9 +97,6 @@
     "default_title": "__MSG_name__"
   },
   "options_page": "/skin/options.html",
-  "storage": {
-    "scripts": "lib/underscore-min.js"
-  },
   "update_url": "http://clients2.google.com/service/update2/crx",
   "web_accessible_resources": [
     "skin/*",

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "unlimitedStorage",
     "storage",
     "cookies",
-    "privacy"
+    "privacy",
+    "downloads"
   ],
   "background": {
     "scripts": [

--- a/skin/options.html
+++ b/skin/options.html
@@ -198,14 +198,14 @@ a, a:hover, a:active, a:visited{
       <p class=""></p>
 
     <div id="import">
-      <h3>Import user data</h3>
+      <h3><span class="i18n_import_user_data"></span></h3>
       <input type="file" id="inputFile" accept=".json">
-      <button id="importTrackerButton" class="importButton" type="submit">Import</button>
+      <button id="importTrackerButton" class="importButton" type="submit"><span class="i18n_import"></span></button>
     </div>
     <div id="export">
-      <h3>Export user data</h3>
+      <h3><span class="i18n_export_user_data"></span></h3>
       <br/>
-      <button id="exportTrackers" class="exportButton">Download</button>
+      <button id="exportTrackers" class="exportButton"><span class="i18n_download"></span></button>
     </div>
   </div>
 

--- a/skin/options.html
+++ b/skin/options.html
@@ -136,6 +136,21 @@ button
   visibility: hidden;
 }
 
+#tab-pb-status {
+  width: 750px;
+  overflow: auto;
+}
+
+#resourceList {
+  width: 450px;
+  float: left;
+}
+
+#importExport {
+  width: 300px;
+  float: left;
+}
+
 /* Filter list entry status message */
 .flMsg {
     display: none;
@@ -173,34 +188,27 @@ a, a:hover, a:active, a:visited{
 
   <div id="tab-pb-status">
     <p class=""></p>
-    <table>
-      <td>
-        <p id="pbInstructions">
-          <span class="i18n_options_pb_has_detected"></span>
-          <span id='count'>0</span>
-          <span class="i18n_options_potential"></span>
-          <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#trackers"><span class="i18n_options_tracking_domains"></span></a>
-          <span class="i18n_options_so_far"></span>
-        </p>
-
-        <div id="blockedResourcesContainer">
-          <div class="spacer"></div>
-          <input id="trackingDomainSearch" type="text" value="" style="width:100%">
-          <div id="blockedResources"><span class="i18n_options_loading"></span></div>
-        </div>
-      </td>
-      <td>
-        <!--TODO fix HTML here so buttons are separated-->
-        <!--<button id="openFileBrowser">Import Trackers</button>-->
-        <!--<form id="importTrackerForm" action="submit">-->
-          <input type="file" id="inputFile" accept=".json">
-          <!--TODO eventually get this to auto submit-->
-          <!--<input id="importTrackers" type="file" accept=".json">-->
-          <button id="importTrackerButton" type="submit">Submit</button>
-        <!--</form>-->
-        <button id="exportTrackers" class="exportButton">Download tracker list</button>
-      </td>
-    </table>
+    <div id="resourceList">
+      <p id="pbInstructions">
+        <span class="i18n_options_pb_has_detected"></span>
+        <span id='count'>0</span>
+        <span class="i18n_options_potential"></span>
+        <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#trackers"><span class="i18n_options_tracking_domains"></span></a>
+        <span class="i18n_options_so_far"></span>
+      </p>
+      <div id="blockedResourcesContainer">
+        <div class="spacer"></div>
+        <input id="trackingDomainSearch" type="text" value="" style="width:100%">
+        <div id="blockedResources"><span class="i18n_options_loading"></span></div>
+      </div>
+    </div>
+    <div id="importExport">
+      <!--TODO eventually get this to auto submit-->
+      <input type="file" id="inputFile" accept=".json">
+      <button id="importTrackerButton" class="importButton" type="submit">Import tracker list</button>
+      <p></p>
+      <button id="exportTrackers" class="exportButton">Download tracker list</button>
+    </div>
   </div>
 
 

--- a/skin/options.html
+++ b/skin/options.html
@@ -102,6 +102,13 @@ button
     display: none;
     color: #b0b0b0;
 }
+
+.importInput{
+  visibility: hidden;
+  height: 0;
+  width: 0;
+}
+
 #blockedResourcesContainer{
   width: 390px;
 }
@@ -198,12 +205,11 @@ a, a:hover, a:active, a:visited{
 
     <div id="import">
       <h3><span class="i18n_import_user_data"></span></h3>
-      <input type="file" id="inputFile" accept=".json">
+      <input type="file" class="importInput" id="importTrackers" accept=".json">
       <button id="importTrackerButton" class="importButton" type="submit"><span class="i18n_import"></span></button>
     </div>
     <div id="export">
       <h3><span class="i18n_export_user_data"></span></h3>
-      <br/>
       <button id="exportTrackers" class="exportButton"><span class="i18n_download"></span></button>
     </div>
   </div>

--- a/skin/options.html
+++ b/skin/options.html
@@ -131,6 +131,11 @@ button
     padding:3px;
 }
 
+#importTrackers {
+  display: block;
+  visibility: hidden;
+}
+
 /* Filter list entry status message */
 .flMsg {
     display: none;
@@ -168,30 +173,34 @@ a, a:hover, a:active, a:visited{
 
   <div id="tab-pb-status">
     <p class=""></p>
-    <div style="float:left">
-      <p id="pbInstructions">
-        <span class="i18n_options_pb_has_detected"></span>
-        <span id='count'>0</span>
-        <span class="i18n_options_potential"></span>
-        <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#trackers"><span class="i18n_options_tracking_domains"></span></a>
-        <span class="i18n_options_so_far"></span>
-      </p>
-    </div>
-    <div id="importExportControls">
-      <table>
-        <tr>
-          <button class="importButton" type="submit">Import tracker list</button>
-        </tr>
-        <tr>
-          <button class="exportButton" type="submit">Export tracker list</button>
-        </tr>
-      </table>
-    </div>
-    <div id="blockedResourcesContainer">
-      <div class="spacer"></div>
-      <input id="trackingDomainSearch" type="text" value="" style="width:100%">
-      <div id="blockedResources"><span class="i18n_options_loading"></span></div>
-    </div>
+    <table>
+      <td>
+        <p id="pbInstructions">
+          <span class="i18n_options_pb_has_detected"></span>
+          <span id='count'>0</span>
+          <span class="i18n_options_potential"></span>
+          <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#trackers"><span class="i18n_options_tracking_domains"></span></a>
+          <span class="i18n_options_so_far"></span>
+        </p>
+
+        <div id="blockedResourcesContainer">
+          <div class="spacer"></div>
+          <input id="trackingDomainSearch" type="text" value="" style="width:100%">
+          <div id="blockedResources"><span class="i18n_options_loading"></span></div>
+        </div>
+      </td>
+      <td>
+        <!--TODO fix HTML here so buttons are separated-->
+        <!--<button id="openFileBrowser">Import Trackers</button>-->
+        <!--<form id="importTrackerForm" action="submit">-->
+          <input type="file" id="inputFile" accept=".json">
+          <!--TODO eventually get this to auto submit-->
+          <!--<input id="importTrackers" type="file" accept=".json">-->
+          <button id="importTrackerButton" type="submit">Submit</button>
+        <!--</form>-->
+        <button id="exportTrackers" class="exportButton">Download tracker list</button>
+      </td>
+    </table>
   </div>
 
 

--- a/skin/options.html
+++ b/skin/options.html
@@ -130,7 +130,7 @@ a, a:hover, a:active, a:visited{
     <li><a href="#tab-pb-status"><span class="i18n_options_filter_settings"></span></a></li>
     <li><a href="#tab-whitelisted"><span class="i18n_whitelisted_domains"></span></a></li>
     <li><a href="#tab-general-settings"><span class="i18n_options_general_settings"></span></a></li>
-    <li><a href="#tab-import-export">Import/Export</a></li>
+    <li><a href="#tab-import-export"><span class="i18n_data_settings"></span></a></li>
   </ul>
     <!-- TODO add i18n string for "Import/Export" -->
 

--- a/skin/options.html
+++ b/skin/options.html
@@ -84,23 +84,16 @@ button
     padding:3px;
 }
 
-#importTrackers {
-  display: block;
-  visibility: hidden;
-}
-
-#tab-pb-status {
+#tab-import-export {
   width: 750px;
   overflow: auto;
 }
-
-#resourceList {
-  width: 450px;
+#import {
+  width: 350px;
   float: left;
 }
-
-#importExport {
-  width: 300px;
+#export {
+  width: 350px;
   float: left;
 }
 
@@ -137,11 +130,13 @@ a, a:hover, a:active, a:visited{
     <li><a href="#tab-pb-status"><span class="i18n_options_filter_settings"></span></a></li>
     <li><a href="#tab-whitelisted"><span class="i18n_whitelisted_domains"></span></a></li>
     <li><a href="#tab-general-settings"><span class="i18n_options_general_settings"></span></a></li>
+    <li><a href="#tab-import-export">Import/Export</a></li>
   </ul>
+    <!-- TODO add i18n string for "Import/Export" -->
 
   <div id="tab-pb-status">
     <p class=""></p>
-    <div id="resourceList">
+    <div id="blockedResourcesContainer">
       <p id="pbInstructions">
         <span class="i18n_options_pb_has_detected"></span>
         <span id='count'>0</span>
@@ -149,18 +144,9 @@ a, a:hover, a:active, a:visited{
         <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#trackers"><span class="i18n_options_tracking_domains"></span></a>
         <span class="i18n_options_so_far"></span>
       </p>
-      <div id="blockedResourcesContainer">
-        <div class="spacer"></div>
-        <input id="trackingDomainSearch" type="text" value="" style="width:100%">
-        <div id="blockedResources"><span class="i18n_options_loading"></span></div>
-      </div>
-    </div>
-    <div id="importExport">
-      <!--TODO eventually get this to auto submit-->
-      <input type="file" id="inputFile" accept=".json">
-      <button id="importTrackerButton" class="importButton" type="submit">Import tracker list</button>
-      <p></p>
-      <button id="exportTrackers" class="exportButton">Download tracker list</button>
+      <div class="spacer"></div>
+      <input id="trackingDomainSearch" type="text" value="" style="width:100%">
+      <div id="blockedResources"><span class="i18n_options_loading"></span></div>
     </div>
   </div>
 
@@ -169,25 +155,25 @@ a, a:hover, a:active, a:visited{
     <p class="i18n_disabled_for_these_domains"></p>
 
     <form id="whitelistForm" action="#">
-    <table>
-      <tr>
-        <td style="max-width:100%">
-          <input type="text" value="" id="newWhitelistDomain" style="width:100%">
-        </td>
-        <td>
-          <button class="addButton" type="submit"><span class="i18n_add_domain_button"></span></button>
-        </td>
-      </tr>
+      <table>
+        <tr>
+          <td style="max-width:100%">
+            <input type="text" value="" id="newWhitelistDomain" style="width:100%">
+          </td>
+          <td>
+            <button class="addButton" type="submit"><span class="i18n_add_domain_button"></span></button>
+          </td>
+        </tr>
 
-      <tr>
-        <td>
-          <select id="excludedDomainsBox" size="10" multiple style="width:500px; background: white;"></select>
-        </td>
-        <td>
-          <button id="removeWhitelist" class="removeButton"><span class="i18n_remove_button"></span></button>
-        </td>
-      </tr>
-    </table>
+        <tr>
+          <td>
+            <select id="excludedDomainsBox" size="10" multiple style="width:500px; background: white;"></select>
+          </td>
+          <td>
+            <button id="removeWhitelist" class="removeButton"><span class="i18n_remove_button"></span></button>
+          </td>
+        </tr>
+      </table>
     </form>
   </div>
 
@@ -204,7 +190,23 @@ a, a:hover, a:active, a:visited{
           <input type="checkbox" id="replace_social_widgets_checkbox">
           <span class="i18n_options_social_widgets_checkbox"></span>
         </label>
+      </div>
     </form>
+  </div>
+
+  <div id="tab-import-export">
+      <p class=""></p>
+
+    <div id="import">
+      <h3>Import user data</h3>
+      <input type="file" id="inputFile" accept=".json">
+      <button id="importTrackerButton" class="importButton" type="submit">Import</button>
+    </div>
+    <div id="export">
+      <h3>Export user data</h3>
+      <br/>
+      <button id="exportTrackers" class="exportButton">Download</button>
+    </div>
   </div>
 
 

--- a/skin/options.html
+++ b/skin/options.html
@@ -132,7 +132,6 @@ a, a:hover, a:active, a:visited{
     <li><a href="#tab-general-settings"><span class="i18n_options_general_settings"></span></a></li>
     <li><a href="#tab-import-export"><span class="i18n_data_settings"></span></a></li>
   </ul>
-    <!-- TODO add i18n string for "Import/Export" -->
 
   <div id="tab-pb-status">
     <p class=""></p>

--- a/skin/options.html
+++ b/skin/options.html
@@ -168,14 +168,26 @@ a, a:hover, a:active, a:visited{
 
   <div id="tab-pb-status">
     <p class=""></p>
-    <div id="blockedResourcesContainer">
+    <div style="float:left">
       <p id="pbInstructions">
-      <span class="i18n_options_pb_has_detected"></span>
-      <span id='count'>0</span>
-      <span class="i18n_options_potential"></span>
-      <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#trackers"><span class="i18n_options_tracking_domains"></span></a>
-      <span class="i18n_options_so_far"></span>
+        <span class="i18n_options_pb_has_detected"></span>
+        <span id='count'>0</span>
+        <span class="i18n_options_potential"></span>
+        <a target=_blank tabindex=-1 title="What is a tracker?" href="https://www.eff.org/privacybadger#trackers"><span class="i18n_options_tracking_domains"></span></a>
+        <span class="i18n_options_so_far"></span>
       </p>
+    </div>
+    <div id="importExportControls">
+      <table>
+        <tr>
+          <button class="importButton" type="submit">Import tracker list</button>
+        </tr>
+        <tr>
+          <button class="exportButton" type="submit">Export tracker list</button>
+        </tr>
+      </table>
+    </div>
+    <div id="blockedResourcesContainer">
       <div class="spacer"></div>
       <input id="trackingDomainSearch" type="text" value="" style="width:100%">
       <div id="blockedResources"><span class="i18n_options_loading"></span></div>

--- a/skin/options.html
+++ b/skin/options.html
@@ -55,60 +55,13 @@ button
 #tabs {
   min-width: 750px;
 }
-#subscriptionTemplate,
-#addSubscriptionContainer,
-#customSubscriptionContainer
-{
-  display: none;
-}
 
-#acceptableAdsContainer
-{
-  margin-top: 10px;
-}
 .tooltipArrow {
   bottom: 27px;
-}
-#acceptableAdsLink,
-#acceptableAdsDocs
-{
-  margin-left: 10px;
-  margin-right: 10px;
-}
-.subscription
-{
-  margin: 3px 0px;
 }
 
 #pbInstructions{
   width:450px;
-}
-
-
-.subscriptionRemoveButton,
-.subscriptionEnabledContainer,
-.subscriptionTitle
-{
-  margin-right: 1em;
-}
-
-.subscriptionRemoveButton
-{
-  font-weight: normal !important;
-  font-size: 20px !important;
-  color: #FF0000 !important;
-  border: none !important;
-  outline: none !important;
-  background: none !important;
-}
-
-.subscriptionUpdate
-{
-  color: #B0B0B0;
-}
-.subscriptionUpdate.error
-{
-  color: #FF0000;
 }
 
 #rawFilters {

--- a/skin/popup.css
+++ b/skin/popup.css
@@ -228,7 +228,7 @@ font-size: 16px;
 .key {
   position: fixed;
   height: 25px;
-  width: 390px;
+  width: 235px;
   z-index: 30;
   background: #fefefe;
   padding-top: 4px;

--- a/src/background.js
+++ b/src/background.js
@@ -66,6 +66,19 @@ function Badger() {
 
     badger.INITIALIZED = true;
   });
+
+  // TODO move this code to actual function, probably in popup.js
+  // chrome.storage.local.get("action_map", function(items) { // null implies all items
+  //   // Convert object to a string.
+  //   var result = JSON.stringify(items);
+  //
+  //   // Save as file
+  //   var url = 'data:application/json;base64,' + btoa(result);
+  //   chrome.downloads.download({
+  //     url: url,
+  //     filename: 'filename_of_exported_file.json'
+  //   });
+  // });
 }
 
 Badger.prototype = {

--- a/src/background.js
+++ b/src/background.js
@@ -66,19 +66,6 @@ function Badger() {
 
     badger.INITIALIZED = true;
   });
-
-  // TODO move this code to actual function, probably in popup.js
-  // chrome.storage.local.get("action_map", function(items) { // null implies all items
-  //   // Convert object to a string.
-  //   var result = JSON.stringify(items);
-  //
-  //   // Save as file
-  //   var url = 'data:application/json;base64,' + btoa(result);
-  //   chrome.downloads.download({
-  //     url: url,
-  //     filename: 'filename_of_exported_file.json'
-  //   });
-  // });
 }
 
 Badger.prototype = {

--- a/src/options.js
+++ b/src/options.js
@@ -87,7 +87,8 @@ function importTrackerList() {
       parseUserDataFile(e.target.result);
     };
   } else {
-    confirm("Please select a file to import.");
+    var selectFile = i18n.getMessage("import_select_file");
+    confirm(selectFile);
   }
 
   document.getElementById("inputFile").value = '';
@@ -105,7 +106,8 @@ function parseUserDataFile(storageMapsList) {
   try {
     lists = JSON.parse(storageMapsList);
   } catch (e) {
-    confirm("Invalid JSON file.");
+    let invalidJSON = i18n.getMessage("invalid_json");
+    confirm(invalidJSON);
     return;
   }
 
@@ -120,8 +122,10 @@ function parseUserDataFile(storageMapsList) {
   }
 
   // Update list to reflect new status of map
+  reloadWhitelist();
   refreshFilterPage();
-  confirm("Tracker list updated successfully!");
+  var importSuccessful = i18n.getMessage("import_successful");
+  confirm(importSuccessful);
 }
 
 /**

--- a/src/options.js
+++ b/src/options.js
@@ -87,7 +87,7 @@ function importTrackerList() {
       parseTrackerList(e.target.result);
     };
   } else {
-      confirm("Please select a file to import.");
+    confirm("Please select a file to import.");
   }
 
   document.getElementById("inputFile").value = '';
@@ -104,7 +104,7 @@ function parseTrackerList(trackerLists) {
   var lists;
 
   try {
-    var lists = JSON.parse(trackerLists);
+    lists = JSON.parse(trackerLists);
   } catch (e) {
     confirm("File must be of type .json.");
   }

--- a/src/options.js
+++ b/src/options.js
@@ -86,6 +86,8 @@ function importTrackerList() {
     reader.onload = function(e) {
       parseTrackerList(e.target.result);
     };
+  } else {
+      confirm("Please select a file to import.");
   }
 
   document.getElementById("inputFile").value = '';
@@ -99,8 +101,14 @@ function importTrackerList() {
  */
 function parseTrackerList(trackerLists) {
   // TODO add error handling to alert user about any errors in supplied file
-  var lists = JSON.parse(trackerLists);
-  //console.log(lists);
+  var lists;
+
+  try {
+    var lists = JSON.parse(trackerLists);
+  } catch (e) {
+    confirm("File must be of type .json.");
+  }
+
   for (var i in lists) {
     var elem = lists[i];
     if (elem.action_map) {
@@ -112,6 +120,7 @@ function parseTrackerList(trackerLists) {
 
   // Update list to reflect new status of map
   refreshFilterPage();
+  confirm("Tracker list updated successfully!");
 }
 
 /**
@@ -123,7 +132,6 @@ function parseTrackerList(trackerLists) {
  * @param map - the map in which the data is to be inserted
  */
 function updateMap(list, map) {
-  console.log("this is list from updateMap: ", list);
   var storageMap;
   if (map === "action_map") {
     storageMap = badger.storage.getBadgerStorageObject("action_map");
@@ -131,7 +139,7 @@ function updateMap(list, map) {
   } else if (map === "snitch_map") {
     storageMap = badger.storage.getBadgerStorageObject("snitch_map");
   } else {
-    return; // TODO add error here since map type is not supported?
+    return; // If map type not supported, skip it
   }
 
   var keys = Object.keys(list);

--- a/src/options.js
+++ b/src/options.js
@@ -81,15 +81,14 @@ function importTrackerList() {
   var file = $('#inputFile')[0].files[0];
 
   if (file) {
-    // console.log(file);
     var reader = new FileReader();
     reader.readAsText(file);
     reader.onload = function(e) {
-      // console.log("output: ", e.target.result);
-      // TODO parse tracker list
       parseTrackerList(e.target.result);
-    }
+    };
   }
+
+  document.getElementById("inputFile").value = '';
 }
 
 /**
@@ -101,27 +100,45 @@ function importTrackerList() {
 function parseTrackerList(trackerLists) {
   // TODO add error handling to alert user about any errors in supplied file
   var lists = JSON.parse(trackerLists);
-  console.log(lists);
-  for (i in lists) {
-    if (lists[i].action_map) {
-      console.log("parsing action_map");
-      updateMap(lists[i].action_map, "action_map");
-    } else if (lists[i].snitch_map) {
-      console.log("parsing snitch_map");
-      updateMap(lists[i].snitch_map, "snitch_map");
+  //console.log(lists);
+  for (var i in lists) {
+    var elem = lists[i];
+    if (elem.action_map) {
+      updateMap(elem.action_map, "action_map");
+    } else if (elem.snitch_map) {
+      updateMap(elem.snitch_map, "snitch_map");
     }
   }
+
+  // Update list to reflect new status of map
+  refreshFilterPage();
 }
 
 /**
  * Update the specified storage map with the elements
- * from the given list
+ * from the given list. Supported maps are currently `action_map`
+ * and `snitch_map`
  *
  * @param list - the list of data to be added
  * @param map - the map in which the data is to be inserted
  */
 function updateMap(list, map) {
-  // TODO insert data from list into appropriate map
+  console.log("this is list from updateMap: ", list);
+  var storageMap;
+  if (map === "action_map") {
+    storageMap = badger.storage.getBadgerStorageObject("action_map");
+
+  } else if (map === "snitch_map") {
+    storageMap = badger.storage.getBadgerStorageObject("snitch_map");
+  } else {
+    return; // TODO add error here since map type is not supported?
+  }
+
+  var keys = Object.keys(list);
+  for (var key in keys) {
+    var domain = keys[key];
+    storageMap.setItem(domain, list[domain]);
+  }
 }
 
 /**

--- a/src/options.js
+++ b/src/options.js
@@ -111,13 +111,11 @@ function parseUserDataFile(storageMapsList) {
     return;
   }
 
-  // var keys = Object.keys(lists);
   for (let map in lists) {
-    // var map = keys[key];
     var storageMap = badger.storage.getBadgerStorageObject(map);
 
     if (storageMap) {
-      storageMap.mergeObject(lists[map]);
+      storageMap.merge(lists[map]);
     }
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -111,9 +111,9 @@ function parseUserDataFile(storageMapsList) {
     return;
   }
 
-  var keys = Object.keys(lists);
-  for (var key in keys) {
-    var map = keys[key];
+  // var keys = Object.keys(lists);
+  for (let map in lists) {
+    // var map = keys[key];
     var storageMap = badger.storage.getBadgerStorageObject(map);
 
     if (storageMap) {

--- a/src/options.js
+++ b/src/options.js
@@ -86,6 +86,8 @@ function importTrackerList() {
     reader.onload = function(e) {
       parseUserDataFile(e.target.result);
     };
+  // TODO let's eliminate this case by consolidating on one button,
+  // the file input, and reacting to its change events
   } else {
     var selectFile = i18n.getMessage("import_select_file");
     confirm(selectFile);
@@ -141,6 +143,7 @@ function exportUserData() {
 
     chrome.downloads.download({
       url: downloadURL,
+      // TODO timestamp
       filename: 'PB_trackers_and_settings.json'
     });
   });

--- a/src/options.js
+++ b/src/options.js
@@ -81,14 +81,47 @@ function importTrackerList() {
   var file = $('#inputFile')[0].files[0];
 
   if (file) {
-    console.log(file);
+    // console.log(file);
     var reader = new FileReader();
     reader.readAsText(file);
     reader.onload = function(e) {
-      console.log("output: ", e.target.result);
+      // console.log("output: ", e.target.result);
       // TODO parse tracker list
+      parseTrackerList(e.target.result);
     }
   }
+}
+
+/**
+ * Parse the tracker lists uploaded by the user, adding to
+ * action_map and snitch_map anything that isn't currently present.
+ *
+ * @param trackerLists - data from JSON file that user provided
+ */
+function parseTrackerList(trackerLists) {
+  // TODO add error handling to alert user about any errors in supplied file
+  var lists = JSON.parse(trackerLists);
+  console.log(lists);
+  for (i in lists) {
+    if (lists[i].action_map) {
+      console.log("parsing action_map");
+      updateMap(lists[i].action_map, "action_map");
+    } else if (lists[i].snitch_map) {
+      console.log("parsing snitch_map");
+      updateMap(lists[i].snitch_map, "snitch_map");
+    }
+  }
+}
+
+/**
+ * Update the specified storage map with the elements
+ * from the given list
+ *
+ * @param list - the list of data to be added
+ * @param map - the map in which the data is to be inserted
+ */
+function updateMap(list, map) {
+  // TODO insert data from list into appropriate map
 }
 
 /**
@@ -99,14 +132,13 @@ function importTrackerList() {
  */
 function exportTrackerList() {
   chrome.storage.local.get("action_map", function(action) {
-    var actionMap = JSON.stringify(action);
 
     chrome.storage.local.get("snitch_map", function(snitch) {
-      var snitchMap = JSON.stringify(snitch);
+      var maps = [];
+      maps.push(action, snitch);
+      var mapJSON = JSON.stringify(maps);
+      var downloadURL = 'data:application/json;base64,' + btoa(mapJSON);
 
-      var maps = actionMap + snitchMap;
-
-      var downloadURL = 'data:application/json;base64,' + btoa(maps);
       chrome.downloads.download({
         url: downloadURL,
         filename: 'PB_tracker_list.json'

--- a/src/options.js
+++ b/src/options.js
@@ -97,7 +97,7 @@ function importTrackerList() {
  * Parse the tracker lists uploaded by the user, adding to the
  * storage maps anything that isn't currently present.
  *
- * @param storageMapsList - data from JSON file that user provided
+ * @param {string} storageMapsList Data from JSON file that user provided
  */
 function parseUserDataFile(storageMapsList) {
   var lists;

--- a/src/options.js
+++ b/src/options.js
@@ -100,7 +100,6 @@ function importTrackerList() {
  * @param trackerLists - data from JSON file that user provided
  */
 function parseTrackerList(trackerLists) {
-  // TODO add error handling to alert user about any errors in supplied file
   var lists;
 
   try {

--- a/src/options.js
+++ b/src/options.js
@@ -38,7 +38,8 @@ function loadOptions() {
   // Add event listeners
   $("#whitelistForm").submit(addWhitelistDomain);
   $("#removeWhitelist").click(removeWhitelistDomain);
-  $('#importTrackerButton').click(importTrackerList);
+  $('#importTrackerButton').click(loadFileChooser);
+  $('#importTrackers').change(importTrackerList);
   $('#exportTrackers').click(exportUserData);
 
   // Set up input for searching through tracking domains.
@@ -74,11 +75,20 @@ function loadOptions() {
 $(loadOptions);
 
 /**
+ * Opens the file chooser to allow a user to select
+ * a file to import.
+ */
+function loadFileChooser() {
+  var fileChooser = document.getElementById('importTrackers');
+  fileChooser.click();
+}
+
+/**
  * Import a list of trackers supplied by the user
- * NOTE: list must be in JSON format to be parseable
+ * NOTE: list must be in JSON format to be parsable
  */
 function importTrackerList() {
-  var file = $('#inputFile')[0].files[0];
+  var file = this.files[0];
 
   if (file) {
     var reader = new FileReader();
@@ -93,7 +103,7 @@ function importTrackerList() {
     confirm(selectFile);
   }
 
-  document.getElementById("inputFile").value = '';
+  document.getElementById("importTrackers").value = '';
 }
 
 /**
@@ -141,10 +151,14 @@ function exportUserData() {
     var mapJSON = JSON.stringify(maps);
     var downloadURL = 'data:application/json;base64,' + btoa(mapJSON);
 
+    // Append the formatted date to the exported file name
+    var currDate = new Date().toLocaleString();
+    var formattedDate = currDate.replace(/[/]/g, '-').replace(/[:,]/g, '_').replace(/ /g, '');
+    var filename = 'PrivacyBadger_user_data_' + formattedDate + '.json';
+
     chrome.downloads.download({
       url: downloadURL,
-      // TODO timestamp
-      filename: 'PB_trackers_and_settings.json'
+      filename: filename
     });
   });
 }

--- a/src/options.js
+++ b/src/options.js
@@ -104,8 +104,6 @@ function importTrackerList() {
     reader.onload = function(e) {
       parseUserDataFile(e.target.result);
     };
-  // TODO let's eliminate this case by consolidating on one button,
-  // the file input, and reacting to its change events
   } else {
     var selectFile = i18n.getMessage("import_select_file");
     confirm(selectFile);

--- a/src/options.js
+++ b/src/options.js
@@ -38,6 +38,8 @@ function loadOptions() {
   // Add event listeners
   $("#whitelistForm").submit(addWhitelistDomain);
   $("#removeWhitelist").click(removeWhitelistDomain);
+  $('#importTrackerButton').click(importTrackerList);
+  $('#exportTrackers').click(exportTrackerList);
 
   // Set up input for searching through tracking domains.
   $("#trackingDomainSearch").attr("placeholder", i18n.getMessage("options_domain_search"));
@@ -50,8 +52,6 @@ function loadOptions() {
     $('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);
     $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
     $('#blockedResourcesContainer').on('click', '.removeOrigin', removeOrigin);
-    $('#importExportControls').on('click', '.importButton', importTrackerList);
-    $('#importExportControls').on('click', '.exportButton', exportTrackerList);
   });
 
   // Display jQuery UI elements
@@ -78,7 +78,17 @@ $(loadOptions);
  * NOTE: list must be in JSON format to be parseable
  */
 function importTrackerList() {
-  // TODO implement function
+  var file = $('#inputFile')[0].files[0];
+
+  if (file) {
+    console.log(file);
+    var reader = new FileReader();
+    reader.readAsText(file);
+    reader.onload = function(e) {
+      console.log("output: ", e.target.result);
+      // TODO parse tracker list
+    }
+  }
 }
 
 /**

--- a/src/options.js
+++ b/src/options.js
@@ -50,6 +50,8 @@ function loadOptions() {
     $('#blockedResourcesContainer').on('mouseleave', '.tooltip', hideTooltip);
     $('#blockedResourcesContainer').on('click', '.userset .honeybadgerPowered', revertDomainControl);
     $('#blockedResourcesContainer').on('click', '.removeOrigin', removeOrigin);
+    $('#importExportControls').on('click', '.importButton', importTrackerList);
+    $('#importExportControls').on('click', '.exportButton', exportTrackerList);
   });
 
   // Display jQuery UI elements
@@ -58,6 +60,8 @@ function loadOptions() {
   $(".refreshButton").button("option", "icons", {primary: "ui-icon-refresh"});
   $(".addButton").button("option", "icons", {primary: "ui-icon-plus"});
   $(".removeButton").button("option", "icons", {primary: "ui-icon-minus"});
+  $(".importButton").button("option", "icons", {primary: "ui-icon-plus"});
+  $(".exportButton").button("option", "icons", {primary: "ui-icon-extlink"});
   $("#show_counter_checkbox").click(updateShowCounter);
   $("#show_counter_checkbox").prop("checked", badger.showCounter());
   $("#replace_social_widgets_checkbox").click(updateSocialWidgetReplacement);
@@ -68,6 +72,38 @@ function loadOptions() {
   refreshFilterPage();
 }
 $(loadOptions);
+
+/**
+ * Import a list of trackers supplied by the user
+ * NOTE: list must be in JSON format to be parseable
+ */
+function importTrackerList() {
+  // TODO implement function
+}
+
+/**
+ * Export the user's list of trackers from action_map and snitch_map.
+ * List will be exported and sent to user via chrome.downloads API
+ * and will be in JSON format that can be edited and reimported
+ * in another instance of Privacy Badger
+ */
+function exportTrackerList() {
+  chrome.storage.local.get("action_map", function(action) {
+    var actionMap = JSON.stringify(action);
+
+    chrome.storage.local.get("snitch_map", function(snitch) {
+      var snitchMap = JSON.stringify(snitch);
+
+      var maps = actionMap + snitchMap;
+
+      var downloadURL = 'data:application/json;base64,' + btoa(maps);
+      chrome.downloads.download({
+        url: downloadURL,
+        filename: 'PB_tracker_list.json'
+      });
+    });
+  });
+}
 
 /**
  * Update setting for whether or not to show counter on Privacy Badger badge.

--- a/src/options.js
+++ b/src/options.js
@@ -106,47 +106,22 @@ function parseUserDataFile(storageMapsList) {
     lists = JSON.parse(storageMapsList);
   } catch (e) {
     confirm("Invalid JSON file.");
+    return;
   }
 
-  for (var i in lists) {
-    var elem = lists[i];
-    if (elem.action_map) {
-      updateMap(elem.action_map, "action_map");
-    } else if (elem.snitch_map) {
-      updateMap(elem.snitch_map, "snitch_map");
+  var keys = Object.keys(lists);
+  for (var key in keys) {
+    var map = keys[key];
+    var storageMap = badger.storage.getBadgerStorageObject(map);
+
+    if (storageMap) {
+      storageMap.mergeObject(lists[map]);
     }
   }
 
   // Update list to reflect new status of map
   refreshFilterPage();
   confirm("Tracker list updated successfully!");
-}
-
-/**
- * Update the specified storage map with the elements
- * from the given list. Supported maps are currently `action_map`
- * and `snitch_map`
- *
- * @param list - the list of data to be added
- * @param map - the map in which the data is to be inserted
- */
-function updateMap(list, map) {
-  // TODO add new function call in storage.js and call that instead of updating here
-  var storageMap;
-  if (map === "action_map") {
-    storageMap = badger.storage.getBadgerStorageObject("action_map");
-
-  } else if (map === "snitch_map") {
-    storageMap = badger.storage.getBadgerStorageObject("snitch_map");
-  } else {
-    return; // If map type not supported, skip it
-  }
-
-  var keys = Object.keys(list);
-  for (var key in keys) {
-    var domain = keys[key];
-    storageMap.setItem(domain, list[domain]);
-  }
 }
 
 /**
@@ -164,7 +139,7 @@ function exportUserData() {
 
     chrome.downloads.download({
       url: downloadURL,
-      filename: 'PB_tracker_list.json'
+      filename: 'PB_trackers_and_settings.json'
     });
   });
 }

--- a/src/storage.js
+++ b/src/storage.js
@@ -428,11 +428,9 @@ BadgerStorage.prototype = {
    *
    * @param {Object} mapData The object containing storage map data to merge
    */
-  mergeObject: function(mapData) {
+  merge: function(mapData) {
     var self = this;
-    // var keys = Object.keys(list);
 
-    // TODO replace the Object.keys calls with standard (let prop in list)
     if (self.name === "settings_map") {
       for (let prop in mapData) {
         if (prop === "disabledSites") {

--- a/src/storage.js
+++ b/src/storage.js
@@ -432,16 +432,10 @@ BadgerStorage.prototype = {
       for (let key in keys) {
         var prop = keys[key];
         if (prop === "disabledSites") {
-          // Add only new sites to list of existing disabled sites
-          // TODO this needs to be defined??
-          if (!self._store[prop]) {
-            self._store[prop] = mapData[prop];
-          } else {
-            var newItems = self.createDedupedArray(mapData[prop], self._store[prop]);
-            self._store[prop] = self._store[prop].concat(newItems);
-          }
+          // Add new sites to list of existing disabled sites
+            self._store[prop] = _.union(self._store[prop], mapData[prop]);
         } else {
-          // Overwrite previous setting with setting from import.
+          // Overwrite existing setting with setting from import.
           self._store[prop] = mapData[prop];
         }
       }
@@ -453,35 +447,9 @@ BadgerStorage.prototype = {
     } else if (self.name === "snitch_map") {
       for (let key in keys) {
         let domain = keys[key];
-        if (self._store[domain]) {
-          // If existing map has data for a specific domain,
-          // concatenate only new items from input
-          // var dedupedArray = self.createDedupedArray(mapData[domain], self._store[domain]);
-          // self._store[domain] = self._store[domain].concat(dedupedArray);
-        } else {
-          self._store[domain] = mapData[domain];
-        }
+        self._store[domain] = _.union(self._store[domain], mapData[domain]);
       }
     }
-  },
-
-  /**
-   * Returns the subset of elements from newList that aren't
-   * currently present in existingList.
-   *
-   * @param {Array} newList The list of new items to be reduced
-   * @param {Array} existingList The list of existing items
-   * @returns {Array} The set from newList that did not exist
-   *          in existingList
-   */
-  createDedupedArray(newList, existingList) {
-    var dedupedArray = [];
-    newList.forEach( entry => {
-      if (existingList.indexOf(entry) === -1) {
-        dedupedArray.push(entry);
-      }
-    });
-    return dedupedArray;
   }
 };
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -416,7 +416,57 @@ BadgerStorage.prototype = {
     setTimeout(function(){
       _syncStorage(self);
     }, 0);
+  },
+
+  /**
+   * Merge the object into the existing map
+   *
+   * @param list - the object containing storage map data to merge
+   */
+  mergeObject: function(list) {
+    var self = this;
+    var keys = Object.keys(list);
+
+    if (self.name === "settings_map") {
+      for (var key in keys) {
+        var prop = keys[key];
+        if (prop === "disabledSites") {
+          // Add only new sites to list of existing disabled sites
+          list[prop].forEach(function(entry) {
+            if (self._store[prop].indexOf(entry) === -1) {
+              self._store[prop].push(entry);
+            }
+          });
+        } else {
+          // Overwrite previous setting with setting from import.
+          self._store[prop] = list[prop];
+        }
+      }
+    } else if (self.name === "action_map") {
+      for (var key in keys) {
+        var domain = keys[key];
+        self._store[domain] = list[domain];
+      }
+    } else if (self.name === "snitch_map") {
+      for (var key in keys) {
+        var domain = keys[key];
+        if (self._store[domain]) {
+          // If array already exists, concatenate deduplicated
+          // version of array from input
+          var dedupedArray = [];
+          list[domain].forEach(function(entry) {
+            if (self._store[domain].indexOf(entry) === -1) {
+              dedupedArray.push(entry);
+            }
+          });
+          self._store[domain] = self._store[domain].concat(dedupedArray);
+        } else {
+          self._store[domain] = list[domain];
+        }
+      }
+    }
   }
+
 };
 
 function _syncStorage(badgerStorage) {

--- a/src/storage.js
+++ b/src/storage.js
@@ -421,20 +421,20 @@ BadgerStorage.prototype = {
   /**
    * Merge the object into the existing map
    *
-   * @param list - the object containing storage map data to merge
+   * @param {Object} list The object containing storage map data to merge
    */
   mergeObject: function(list) {
     var self = this;
     var keys = Object.keys(list);
 
     if (self.name === "settings_map") {
-      for (var key in keys) {
+      for (let key in keys) {
         var prop = keys[key];
         if (prop === "disabledSites") {
           // Add only new sites to list of existing disabled sites
-          list[prop].forEach(function(entry) {
+          list[prop].forEach( entry => {
             if (self._store[prop].indexOf(entry) === -1) {
-              self._store[prop].push(entry);
+            self._store[prop].push(entry);
             }
           });
         } else {
@@ -443,18 +443,18 @@ BadgerStorage.prototype = {
         }
       }
     } else if (self.name === "action_map") {
-      for (var key in keys) {
-        var domain = keys[key];
+      for (let key in keys) {
+        let domain = keys[key];
         self._store[domain] = list[domain];
       }
     } else if (self.name === "snitch_map") {
-      for (var key in keys) {
-        var domain = keys[key];
+      for (let key in keys) {
+        let domain = keys[key];
         if (self._store[domain]) {
           // If array already exists, concatenate deduplicated
           // version of array from input
           var dedupedArray = [];
-          list[domain].forEach(function(entry) {
+          list[domain].forEach( entry => {
             if (self._store[domain].indexOf(entry) === -1) {
               dedupedArray.push(entry);
             }

--- a/src/storage.js
+++ b/src/storage.js
@@ -447,10 +447,11 @@ BadgerStorage.prototype = {
         self._store[domain] = mapData[domain];
       }
     } else if (self.name === "snitch_map") {
-      for (let domain in mapData) {
-        // TODO how is snitch_map used? what happens if union op results in a "new tracker"?
-        // Merge any new domains into each existing snitch_map key
-        self._store[domain] = _.union(self._store[domain], mapData[domain]);
+      for (let thirdPartyTracker in mapData) {
+        var firstPartyOrigins = mapData[thirdPartyTracker];
+        for (let origin in firstPartyOrigins) {
+          badger.heuristicBlocking.recordPrevalence(thirdPartyTracker, firstPartyOrigins[origin]);
+        }
       }
     }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -433,7 +433,7 @@ BadgerStorage.prototype = {
         var prop = keys[key];
         if (prop === "disabledSites") {
           // Add new sites to list of existing disabled sites
-            self._store[prop] = _.union(self._store[prop], mapData[prop]);
+          self._store[prop] = _.union(self._store[prop], mapData[prop]);
         } else {
           // Overwrite existing setting with setting from import.
           self._store[prop] = mapData[prop];

--- a/src/storage.js
+++ b/src/storage.js
@@ -454,7 +454,10 @@ BadgerStorage.prototype = {
       }
     }
 
-    // TODO do we need to call _syncStorage?
+    // Async call to syncStorage.
+    setTimeout(function(){
+      _syncStorage(self);
+    }, 0);
   }
 };
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -433,11 +433,13 @@ BadgerStorage.prototype = {
         var prop = keys[key];
         if (prop === "disabledSites") {
           // Add only new sites to list of existing disabled sites
-          mapData[prop].forEach( entry => {
-            if (self._store[prop].indexOf(entry) === -1) {
-              self._store[prop].push(entry);
-            }
-          });
+          // TODO this needs to be defined??
+          if (!self._store[prop]) {
+            self._store[prop] = mapData[prop];
+          } else {
+            var newItems = self.createDedupedArray(mapData[prop], self._store[prop]);
+            self._store[prop] = self._store[prop].concat(newItems);
+          }
         } else {
           // Overwrite previous setting with setting from import.
           self._store[prop] = mapData[prop];
@@ -452,11 +454,10 @@ BadgerStorage.prototype = {
       for (let key in keys) {
         let domain = keys[key];
         if (self._store[domain]) {
-          // If array already exists, concatenate deduplicated
-          // version of array from input
-
-          var dedupedArray = self.createDedupedArray(list[domain], self._store[domain]);
-          self._store[domain] = self._store[domain].concat(dedupedArray);
+          // If existing map has data for a specific domain,
+          // concatenate only new items from input
+          // var dedupedArray = self.createDedupedArray(mapData[domain], self._store[domain]);
+          // self._store[domain] = self._store[domain].concat(dedupedArray);
         } else {
           self._store[domain] = mapData[domain];
         }
@@ -464,10 +465,19 @@ BadgerStorage.prototype = {
     }
   },
 
+  /**
+   * Returns the subset of elements from newList that aren't
+   * currently present in existingList.
+   *
+   * @param {Array} newList The list of new items to be reduced
+   * @param {Array} existingList The list of existing items
+   * @returns {Array} The set from newList that did not exist
+   *          in existingList
+   */
   createDedupedArray(newList, existingList) {
-    var dedupedArray;
+    var dedupedArray = [];
     newList.forEach( entry => {
-      if (existingList.indexOf(entry) === -1 && entry) {
+      if (existingList.indexOf(entry) === -1) {
         dedupedArray.push(entry);
       }
     });

--- a/src/storage.js
+++ b/src/storage.js
@@ -419,18 +419,22 @@ BadgerStorage.prototype = {
   },
 
   /**
-   * Merge the object into the existing map
+   * When a user imports a tracker and settings list via the Import function,
+   * we want to overwrite any existing settings, while simultaneously merging
+   * in any new information (i.e. the set of whitelisted domains). In order
+   * to do this, we need different logic for each of the storage maps based on
+   * their internal structure. The three cases in this function handle each of
+   * the three storage maps that can be exported.
    *
-   * @param {Object} list The object containing storage map data to merge
+   * @param {Object} mapData The object containing storage map data to merge
    */
-  mergeObject: function(list) {
+  mergeObject: function(mapData) {
     var self = this;
-    var keys = Object.keys(list);
-    let mapData = list;
+    // var keys = Object.keys(list);
 
+    // TODO replace the Object.keys calls with standard (let prop in list)
     if (self.name === "settings_map") {
-      for (let key in keys) {
-        var prop = keys[key];
+      for (let prop in mapData) {
         if (prop === "disabledSites") {
           // Add new sites to list of existing disabled sites
           self._store[prop] = _.union(self._store[prop], mapData[prop]);
@@ -440,13 +444,13 @@ BadgerStorage.prototype = {
         }
       }
     } else if (self.name === "action_map") {
-      for (let key in keys) {
-        let domain = keys[key];
+      for (let domain in mapData) {
+        // Overwrite local setting (if exists) for any imported domain
         self._store[domain] = mapData[domain];
       }
     } else if (self.name === "snitch_map") {
-      for (let key in keys) {
-        let domain = keys[key];
+      for (let domain in mapData) {
+        // Merge any new domains into each existing snitch_map key
         self._store[domain] = _.union(self._store[domain], mapData[domain]);
       }
     }

--- a/src/storage.js
+++ b/src/storage.js
@@ -426,26 +426,27 @@ BadgerStorage.prototype = {
   mergeObject: function(list) {
     var self = this;
     var keys = Object.keys(list);
+    let mapData = list;
 
     if (self.name === "settings_map") {
       for (let key in keys) {
         var prop = keys[key];
         if (prop === "disabledSites") {
           // Add only new sites to list of existing disabled sites
-          list[prop].forEach( entry => {
+          mapData[prop].forEach( entry => {
             if (self._store[prop].indexOf(entry) === -1) {
             self._store[prop].push(entry);
             }
           });
         } else {
           // Overwrite previous setting with setting from import.
-          self._store[prop] = list[prop];
+          self._store[prop] = mapData[prop];
         }
       }
     } else if (self.name === "action_map") {
       for (let key in keys) {
         let domain = keys[key];
-        self._store[domain] = list[domain];
+        self._store[domain] = mapData[domain];
       }
     } else if (self.name === "snitch_map") {
       for (let key in keys) {
@@ -454,14 +455,14 @@ BadgerStorage.prototype = {
           // If array already exists, concatenate deduplicated
           // version of array from input
           var dedupedArray = [];
-          list[domain].forEach( entry => {
+          mapData[domain].forEach( entry => {
             if (self._store[domain].indexOf(entry) === -1) {
               dedupedArray.push(entry);
             }
           });
           self._store[domain] = self._store[domain].concat(dedupedArray);
         } else {
-          self._store[domain] = list[domain];
+          self._store[domain] = mapData[domain];
         }
       }
     }

--- a/src/storage.js
+++ b/src/storage.js
@@ -448,10 +448,13 @@ BadgerStorage.prototype = {
       }
     } else if (self.name === "snitch_map") {
       for (let domain in mapData) {
+        // TODO how is snitch_map used? what happens if union op results in a "new tracker"?
         // Merge any new domains into each existing snitch_map key
         self._store[domain] = _.union(self._store[domain], mapData[domain]);
       }
     }
+
+    // TODO do we need to call _syncStorage?
   }
 };
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -435,7 +435,7 @@ BadgerStorage.prototype = {
           // Add only new sites to list of existing disabled sites
           mapData[prop].forEach( entry => {
             if (self._store[prop].indexOf(entry) === -1) {
-            self._store[prop].push(entry);
+              self._store[prop].push(entry);
             }
           });
         } else {
@@ -454,20 +454,25 @@ BadgerStorage.prototype = {
         if (self._store[domain]) {
           // If array already exists, concatenate deduplicated
           // version of array from input
-          var dedupedArray = [];
-          mapData[domain].forEach( entry => {
-            if (self._store[domain].indexOf(entry) === -1) {
-              dedupedArray.push(entry);
-            }
-          });
+
+          var dedupedArray = self.createDedupedArray(list[domain], self._store[domain]);
           self._store[domain] = self._store[domain].concat(dedupedArray);
         } else {
           self._store[domain] = mapData[domain];
         }
       }
     }
-  }
+  },
 
+  createDedupedArray(newList, existingList) {
+    var dedupedArray;
+    newList.forEach( entry => {
+      if (existingList.indexOf(entry) === -1 && entry) {
+        dedupedArray.push(entry);
+      }
+    });
+    return dedupedArray;
+  }
 };
 
 function _syncStorage(badgerStorage) {

--- a/src/webrequest.js
+++ b/src/webrequest.js
@@ -409,7 +409,7 @@ function recordFingerprinting(tabId, msg) {
 
           // Mark this is a strike
           badger.heuristicBlocking.recordPrevalence(
-            script_host, script_origin, window.getBaseDomain(document_host));
+            script_host, window.getBaseDomain(document_host));
         }
       }
       // This is a canvas write

--- a/tests/tests/storage.js
+++ b/tests/tests/storage.js
@@ -1,6 +1,22 @@
 /* globals badger:false */
 (function() {
-  module("Privacy Badger Storage");
+  let settings_map, DISABLED_SITES, SHOW_COUNTER;
+
+  module("Privacy Badger Storage", {
+    setup: () => {
+      settings_map = badger.storage.getBadgerStorageObject('settings_map');
+
+      // back up original settings
+      DISABLED_SITES = settings_map.getItem('disabledSites');
+      SHOW_COUNTER = settings_map.getItem('showCounter');
+    },
+
+    teardown: () => {
+      // restore original settings
+      settings_map.setItem('disabledSites', DISABLED_SITES);
+      settings_map.setItem('showCounter', SHOW_COUNTER);
+    }
+  });
 
   test("testGetBadgerStorage", function(){
     expect(1);
@@ -42,4 +58,31 @@
     }, 500);*/
     ok(true);
   });
+
+  test("every badger storage map has a merge method", () => {
+    ['action_map', 'settings_map', 'snitch_map'].forEach(obj => {
+      ok(typeof badger.storage.getBadgerStorageObject(obj).merge == "function");
+    });
+  });
+
+  test("settings map merging", () => {
+    // overwrite settings with test values
+    settings_map.setItem('disabledSites', ['example.com']);
+    settings_map.setItem('showCounter', true);
+
+    // merge settings
+    settings_map.merge({
+      disabledSites: ['www.nytimes.com'],
+      showCounter: false,
+    });
+
+    // verify
+    deepEqual(
+     settings_map.getItem('disabledSites'),
+     ['example.com', 'www.nytimes.com'],
+      "disabled site lists are combined when merging settings"
+    );
+    ok(!settings_map.getItem('showCounter'), "other settings are overwritten");
+  });
+
 })();

--- a/tests/tests/storage.js
+++ b/tests/tests/storage.js
@@ -85,12 +85,42 @@
     ok(!settings_map.getItem('showCounter'), "other settings are overwritten");
   });
 
-  // TODO
-  //test("action map merging", () => {
-  //});
+  test("action map merging", () => {
+    expect(2);
+    let action_map = badger.storage.getBadgerStorageObject('action_map');
 
-  // TODO
-  //test("snitch map merging", () => {
-  //});
+    action_map.setItem('testsite.com',
+        {dnt: false, heuristicAction: "", nextUpdateTime: 100, userAction: ""});
+    ok(action_map.getItem('testsite.com').nextUpdateTime === 100);
+
+    let newValue = {dnt: false, heuristicAction: "", nextUpdateTime: 101, userAction: ""};
+    action_map.merge({'testsite.com': newValue});
+
+    // Merged in object should have new nextUpdateTime value
+    ok(action_map.getItem('testsite.com').nextUpdateTime === 101);
+  });
+
+
+  test("snitch map merging", () => {
+    expect(5);
+    let snitch_map = badger.storage.getBadgerStorageObject('snitch_map');
+    let action_map = badger.storage.getBadgerStorageObject('action_map');
+
+    action_map.setItem('testsite.com',
+        {dnt: false, heuristicAction: "", nextUpdateTime: 100, userAction: ""});
+
+    snitch_map.setItem('testsite.com', ['firstparty.org']);
+    ok(snitch_map.getItem('testsite.com').indexOf('firstparty.org') > -1);
+
+    // Check to make sure existing and new domain are present
+    snitch_map.merge({"testsite.com": ['firstparty2.org']});
+    ok(snitch_map.getItem('testsite.com').indexOf('firstparty.org') > -1);
+    ok(snitch_map.getItem('testsite.com').indexOf('firstparty2.org') > -1);
+
+    // Verify 'block' status is triggered once TRACKING_THRESHOLD is hit
+    ok(action_map.getItem('testsite.com').heuristicAction === "allow");
+    snitch_map.merge({'testsite.com': ["firstparty3.org"]});
+    ok(action_map.getItem('testsite.com').heuristicAction === "block");
+  });
 
 })();

--- a/tests/tests/storage.js
+++ b/tests/tests/storage.js
@@ -85,4 +85,12 @@
     ok(!settings_map.getItem('showCounter'), "other settings are overwritten");
   });
 
+  // TODO
+  //test("action map merging", () => {
+  //});
+
+  // TODO
+  //test("snitch map merging", () => {
+  //});
+
 })();

--- a/tests/tests/storage.js
+++ b/tests/tests/storage.js
@@ -1,20 +1,24 @@
 /* globals badger:false */
 (function() {
-  let settings_map, DISABLED_SITES, SHOW_COUNTER;
+  let BACKUP = {};
 
   module("Privacy Badger Storage", {
+    // note: setup is not module-level, called before every test
     setup: () => {
-      settings_map = badger.storage.getBadgerStorageObject('settings_map');
-
-      // back up original settings
-      DISABLED_SITES = settings_map.getItem('disabledSites');
-      SHOW_COUNTER = settings_map.getItem('showCounter');
+      // back up settings and heuristic learning
+      ['action_map', 'settings_map', 'snitch_map'].forEach(item => {
+        let obj = badger.storage.getBadgerStorageObject(item);
+        BACKUP[item] = obj.getItemClones();
+      });
     },
 
+    // called after every test
     teardown: () => {
-      // restore original settings
-      settings_map.setItem('disabledSites', DISABLED_SITES);
-      settings_map.setItem('showCounter', SHOW_COUNTER);
+      // restore original settings and heuristic learning
+      ['action_map', 'settings_map', 'snitch_map'].forEach(item => {
+        let obj = badger.storage.getBadgerStorageObject(item);
+        obj.updateObject(BACKUP[item]);
+      });
     }
   });
 
@@ -59,13 +63,9 @@
     ok(true);
   });
 
-  test("every badger storage map has a merge method", () => {
-    ['action_map', 'settings_map', 'snitch_map'].forEach(obj => {
-      ok(typeof badger.storage.getBadgerStorageObject(obj).merge == "function");
-    });
-  });
-
   test("settings map merging", () => {
+    let settings_map = badger.storage.getBadgerStorageObject('settings_map');
+
     // overwrite settings with test values
     settings_map.setItem('disabledSites', ['example.com']);
     settings_map.setItem('showCounter', true);

--- a/tests/tests/storage.js
+++ b/tests/tests/storage.js
@@ -2,49 +2,44 @@
 (function() {
   module("Privacy Badger Storage");
 
-  var BadgerStore = require('storage');
+  test("testGetBadgerStorage", function(){
+    expect(1);
+    var action_map = badger.storage.getBadgerStorageObject('action_map');
+    ok(action_map.updateObject instanceof Function, "action_map is a pbstorage");
+  });
 
-  new BadgerStore.BadgerPen(function(){ // eslint-disable-line no-new
-  
-    test("testGetBadgerStorage", function(){
-      expect(1);
-      var action_map = badger.storage.getBadgerStorageObject('action_map');
-      ok(action_map.updateObject instanceof Function, "action_map is a pbstorage");
-    });
+  test("test BadgerStorage methods", function(){
+    expect(3);
+    var action_map = badger.storage.getBadgerStorageObject('action_map');
+    action_map.setItem('foo', 'bar');
+    ok(action_map.getItem('foo') === 'bar');
+    ok(action_map.hasItem('foo'));
+    action_map.deleteItem('foo');
+    ok(!action_map.hasItem('foo'));
+  });
 
-    test("test BadgerStorage methods", function(){
-      expect(3);
-      var action_map = badger.storage.getBadgerStorageObject('action_map');
-      action_map.setItem('foo', 'bar');
-      ok(action_map.getItem('foo') === 'bar');
-      ok(action_map.hasItem('foo'));
-      action_map.deleteItem('foo'); 
-      ok(!action_map.hasItem('foo'));
-    });
+  test("test user override of default action for domain", function(){
+    expect(4);
+    badger.saveAction("allow", "pbtest.org");
+    ok(badger.userAllow.indexOf('pbtest.org') > -1);
+    badger.saveAction("block", "pbtest.org");
+    ok(badger.userAllow.indexOf('pbtest.org') <= -1);
+    badger.saveAction("allow", "pbtest.org");
+    ok(badger.userAllow.indexOf('pbtest.org') > -1);
+    badger.storage.revertUserAction("pbtest.org");
+    ok(badger.userAllow.indexOf('pbtest.org') <= -1);
+  });
 
-    test("test user override of default action for domain", function(){
-      expect(4);
-      badger.saveAction("allow", "pbtest.org");
-      ok(badger.userAllow.indexOf('pbtest.org') > -1);
-      badger.saveAction("block", "pbtest.org");
-      ok(badger.userAllow.indexOf('pbtest.org') <= -1);
-      badger.saveAction("allow", "pbtest.org");
-      ok(badger.userAllow.indexOf('pbtest.org') > -1);
-      badger.storage.revertUserAction("pbtest.org");
-      ok(badger.userAllow.indexOf('pbtest.org') <= -1);
-    });
-
-    test("data persists to local storage", function(){
-      // TODO: Figure out how to test this. 
-      expect(1); //expect 1 assertion
-      /*var action_map = BadgerStore.getBadgerStorageObject('action_map');
-      action_map.setItem('foo', 'bar');
-      setTimeout(function(){
-        var data = JSON.parse(localStorage.getItem('action_map'));
-        ok(data.foo == 'bar', "data presists to local storage");
-        start();
-      }, 500);*/
-      ok(true);
-    });
+  test("data persists to local storage", function(){
+    // TODO: Figure out how to test this.
+    expect(1); //expect 1 assertion
+    /*var action_map = BadgerStore.getBadgerStorageObject('action_map');
+    action_map.setItem('foo', 'bar');
+    setTimeout(function(){
+      var data = JSON.parse(localStorage.getItem('action_map'));
+      ok(data.foo == 'bar', "data persists to local storage");
+      start();
+    }, 500);*/
+    ok(true);
   });
 })();


### PR DESCRIPTION
@cooperq @ghostwords 

This pull request implements the features requested in #121.

The current implementation only covers `action_map` and `snitch_map`, as `settings_map` currently only has two items, and it seemed a bit strange to me to be exporting `settings_map` data along with tracker data since "Settings" has its own tab on the Options page.

EXPORT:
Allows a user to download the data from `action_map` and `snitch_map` in JSON format, not as a binary object.

IMPORT:
Allows a user to import data from a file that is (a) in JSON format and (b) has the same structure as the file that Privacy Badger exports. Import acts as a semi-union: if a given domain *does not* exist in the current map, it will be added; if a given domain *does* exist, it will be overwritten with the object from the supplied file.


Do we need to do anything on `action_map` with regard to `nextUpdateTime` once we finish importing, especially as an imported file can contain old data?

The current code does work according to my manual tests, though I think it's wise to discuss the current implementation before determining that the existing behavior is the desired behavior. Once that's done I'll write up some tests that can be run as part of the test suite.